### PR TITLE
Add preview gender selection, smart gender defaults, and hotkeys

### DIFF
--- a/Models/ArmorPreviewScene.cs
+++ b/Models/ArmorPreviewScene.cs
@@ -34,41 +34,40 @@ public sealed record OutfitMetadata(
 
 public sealed class ArmorPreviewSceneCollection
 {
-    private readonly Dictionary<int, ArmorPreviewScene> _sceneCache = new();
-    private readonly Func<int, Task<ArmorPreviewScene>> _sceneBuilder;
+    private readonly Dictionary<(int Index, GenderedModelVariant Gender), ArmorPreviewScene> _sceneCache = new();
+    private readonly Func<int, GenderedModelVariant, Task<ArmorPreviewScene>> _sceneBuilder;
 
     public int Count { get; }
     public int InitialIndex { get; }
+    public GenderedModelVariant InitialGender { get; }
     public IReadOnlyList<OutfitMetadata> Metadata { get; }
-
-    public ArmorPreviewSceneCollection(ArmorPreviewScene singleScene)
-    {
-        Count = 1;
-        InitialIndex = 0;
-        Metadata = new[] { new OutfitMetadata(singleScene.OutfitLabel, singleScene.SourceFile, singleScene.IsWinner) };
-        _sceneCache[0] = singleScene;
-        _sceneBuilder = _ => Task.FromResult(singleScene);
-    }
 
     public ArmorPreviewSceneCollection(
         int count,
         int initialIndex,
         IReadOnlyList<OutfitMetadata> metadata,
-        Func<int, Task<ArmorPreviewScene>> sceneBuilder)
+        Func<int, GenderedModelVariant, Task<ArmorPreviewScene>> sceneBuilder,
+        GenderedModelVariant initialGender = GenderedModelVariant.Female)
     {
         Count = count;
         InitialIndex = initialIndex;
+        InitialGender = initialGender;
         Metadata = metadata;
         _sceneBuilder = sceneBuilder;
     }
 
-    public async Task<ArmorPreviewScene> GetSceneAsync(int index)
+    public async Task<ArmorPreviewScene> GetSceneAsync(int index, GenderedModelVariant gender)
     {
-        if (_sceneCache.TryGetValue(index, out var cached))
+        if (_sceneCache.TryGetValue((index, gender), out var cached))
             return cached;
 
-        var scene = await _sceneBuilder(index);
-        _sceneCache[index] = scene;
+        var scene = await _sceneBuilder(index, gender);
+        _sceneCache[(index, gender)] = scene;
         return scene;
+    }
+
+    public void ClearCache()
+    {
+        _sceneCache.Clear();
     }
 }

--- a/ViewModels/DistributionNpcsTabViewModel.cs
+++ b/ViewModels/DistributionNpcsTabViewModel.cs
@@ -325,13 +325,24 @@ public class DistributionNpcsTabViewModel : ReactiveObject
         try
         {
             StatusMessage = $"Building preview for {label}...";
-            var scene = await _armorPreviewService.BuildPreviewAsync(armorPieces, GenderedModelVariant.Female);
-            var sceneWithMetadata = scene with
-            {
-                OutfitLabel = label,
-                SourceFile = outfit.FormKey.ModKey.FileName.String
-            };
-            var collection = new ArmorPreviewSceneCollection(sceneWithMetadata);
+
+            var npcGender = GetNpcGender(npcAssignment.NpcFormKey, linkCache);
+            var metadata = new OutfitMetadata(label, outfit.FormKey.ModKey.FileName.String, false);
+            var collection = new ArmorPreviewSceneCollection(
+                count: 1,
+                initialIndex: 0,
+                metadata: new[] { metadata },
+                sceneBuilder: async (_, gender) =>
+                {
+                    var scene = await _armorPreviewService.BuildPreviewAsync(armorPieces, gender);
+                    return scene with
+                    {
+                        OutfitLabel = label,
+                        SourceFile = outfit.FormKey.ModKey.FileName.String
+                    };
+                },
+                initialGender: npcGender);
+
             await ShowPreview.Handle(collection);
             StatusMessage = $"Preview ready for {label}.";
         }
@@ -381,11 +392,12 @@ public class DistributionNpcsTabViewModel : ReactiveObject
                     d.IsWinner))
                 .ToList();
 
+            var npcGender = GetNpcGender(SelectedNpcAssignment.NpcFormKey, linkCache);
             var collection = new ArmorPreviewSceneCollection(
                 distributions.Count,
                 clickedIndex,
                 metadata,
-                async index =>
+                async (index, gender) =>
                 {
                     var distribution = distributions[index];
 
@@ -396,14 +408,15 @@ public class DistributionNpcsTabViewModel : ReactiveObject
                     if (armorPieces.Count == 0)
                         throw new InvalidOperationException($"Outfit '{outfit.EditorID ?? outfit.FormKey.ToString()}' has no armor pieces");
 
-                    var scene = await _armorPreviewService.BuildPreviewAsync(armorPieces, GenderedModelVariant.Female);
+                    var scene = await _armorPreviewService.BuildPreviewAsync(armorPieces, gender);
                     return scene with
                     {
                         OutfitLabel = distribution.OutfitEditorId ?? distribution.OutfitFormKey.ToString(),
                         SourceFile = distribution.FileName,
                         IsWinner = distribution.IsWinner
                     };
-                });
+                },
+                initialGender: npcGender);
 
             await ShowPreview.Handle(collection);
             StatusMessage = $"Preview ready with {distributions.Count} outfit(s).";
@@ -652,5 +665,17 @@ public class DistributionNpcsTabViewModel : ReactiveObject
         }
 
         SelectedNpcOutfitContents = sb.ToString();
+    }
+
+    private static GenderedModelVariant GetNpcGender(FormKey npcFormKey, ILinkCache<ISkyrimMod, ISkyrimModGetter> linkCache)
+    {
+        if (linkCache.TryResolve<INpcGetter>(npcFormKey, out var npc))
+        {
+            return npc.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Female)
+                ? GenderedModelVariant.Female
+                : GenderedModelVariant.Male;
+        }
+
+        return GenderedModelVariant.Female;
     }
 }

--- a/ViewModels/DistributionOutfitsTabViewModel.cs
+++ b/ViewModels/DistributionOutfitsTabViewModel.cs
@@ -242,13 +242,23 @@ public class DistributionOutfitsTabViewModel : ReactiveObject
         try
         {
             StatusMessage = $"Building preview for {label}...";
-            var scene = await _armorPreviewService.BuildPreviewAsync(armorPieces, GenderedModelVariant.Female);
-            var sceneWithMetadata = scene with
-            {
-                OutfitLabel = label,
-                SourceFile = outfit.FormKey.ModKey.FileName.String
-            };
-            var collection = new ArmorPreviewSceneCollection(sceneWithMetadata);
+
+            var metadata = new OutfitMetadata(label, outfit.FormKey.ModKey.FileName.String, false);
+            var collection = new ArmorPreviewSceneCollection(
+                count: 1,
+                initialIndex: 0,
+                metadata: new[] { metadata },
+                sceneBuilder: async (_, gender) =>
+                {
+                    var scene = await _armorPreviewService.BuildPreviewAsync(armorPieces, gender);
+                    return scene with
+                    {
+                        OutfitLabel = label,
+                        SourceFile = outfit.FormKey.ModKey.FileName.String
+                    };
+                },
+                initialGender: GenderedModelVariant.Female);
+
             await ShowPreview.Handle(collection);
             StatusMessage = $"Preview ready for {label}.";
         }
@@ -289,17 +299,36 @@ public class DistributionOutfitsTabViewModel : ReactiveObject
             return;
         }
 
+        var owningNpc = SelectedOutfitNpcAssignments
+            .FirstOrDefault(npc => npc.Distributions.Contains(clickedDistribution));
+        var initialGender = owningNpc != null
+            ? GetNpcGender(owningNpc.NpcFormKey, linkCache)
+            : GenderedModelVariant.Female;
+
         try
         {
             StatusMessage = $"Building preview for {label}...";
-            var scene = await _armorPreviewService.BuildPreviewAsync(armorPieces, GenderedModelVariant.Female);
-            var sceneWithMetadata = scene with
-            {
-                OutfitLabel = clickedDistribution.OutfitEditorId ?? clickedDistribution.OutfitFormKey.ToString(),
-                SourceFile = clickedDistribution.FileName,
-                IsWinner = clickedDistribution.IsWinner
-            };
-            var collection = new ArmorPreviewSceneCollection(sceneWithMetadata);
+
+            var metadata = new OutfitMetadata(
+                clickedDistribution.OutfitEditorId ?? clickedDistribution.OutfitFormKey.ToString(),
+                clickedDistribution.FileName,
+                clickedDistribution.IsWinner);
+            var collection = new ArmorPreviewSceneCollection(
+                count: 1,
+                initialIndex: 0,
+                metadata: new[] { metadata },
+                sceneBuilder: async (_, gender) =>
+                {
+                    var scene = await _armorPreviewService.BuildPreviewAsync(armorPieces, gender);
+                    return scene with
+                    {
+                        OutfitLabel = clickedDistribution.OutfitEditorId ?? clickedDistribution.OutfitFormKey.ToString(),
+                        SourceFile = clickedDistribution.FileName,
+                        IsWinner = clickedDistribution.IsWinner
+                    };
+                },
+                initialGender: initialGender);
+
             await ShowPreview.Handle(collection);
             StatusMessage = $"Preview ready for {label}.";
         }
@@ -465,5 +494,17 @@ public class DistributionOutfitsTabViewModel : ReactiveObject
                 outfit.NpcCount = 0;
             }
         }
+    }
+
+    private static GenderedModelVariant GetNpcGender(FormKey npcFormKey, ILinkCache<ISkyrimMod, ISkyrimModGetter> linkCache)
+    {
+        if (linkCache.TryResolve<INpcGetter>(npcFormKey, out var npc))
+        {
+            return npc.Configuration.Flags.HasFlag(NpcConfiguration.Flag.Female)
+                ? GenderedModelVariant.Female
+                : GenderedModelVariant.Male;
+        }
+
+        return GenderedModelVariant.Female;
     }
 }

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -1481,12 +1481,21 @@ public class MainViewModel : ReactiveObject
         try
         {
             StatusMessage = $"Building preview for '{draft.EditorId}'...";
-            var scene = await _previewService.BuildPreviewAsync(pieces, GenderedModelVariant.Female);
-            var sceneWithMetadata = scene with
-            {
-                OutfitLabel = draft.EditorId
-            };
-            var collection = new ArmorPreviewSceneCollection(sceneWithMetadata);
+
+            var metadata = new OutfitMetadata(draft.EditorId, null, false);
+            var collection = new ArmorPreviewSceneCollection(
+                count: 1,
+                initialIndex: 0,
+                metadata: new[] { metadata },
+                sceneBuilder: async (_, gender) =>
+                {
+                    var scene = await _previewService.BuildPreviewAsync(pieces, gender);
+                    return scene with
+                    {
+                        OutfitLabel = draft.EditorId
+                    };
+                });
+
             await ShowPreview.Handle(collection);
             StatusMessage = $"Preview ready for '{draft.EditorId}'.";
         }
@@ -1502,13 +1511,22 @@ public class MainViewModel : ReactiveObject
         try
         {
             StatusMessage = $"Building preview for '{armor.DisplayName}'...";
-            var scene = await _previewService.BuildPreviewAsync([armor], GenderedModelVariant.Female);
-            var sceneWithMetadata = scene with
-            {
-                OutfitLabel = armor.DisplayName,
-                SourceFile = armor.Armor.FormKey.ModKey.FileName.String
-            };
-            var collection = new ArmorPreviewSceneCollection(sceneWithMetadata);
+
+            var metadata = new OutfitMetadata(armor.DisplayName, armor.Armor.FormKey.ModKey.FileName.String, false);
+            var collection = new ArmorPreviewSceneCollection(
+                count: 1,
+                initialIndex: 0,
+                metadata: new[] { metadata },
+                sceneBuilder: async (_, gender) =>
+                {
+                    var scene = await _previewService.BuildPreviewAsync([armor], gender);
+                    return scene with
+                    {
+                        OutfitLabel = armor.DisplayName,
+                        SourceFile = armor.Armor.FormKey.ModKey.FileName.String
+                    };
+                });
+
             await ShowPreview.Handle(collection);
             StatusMessage = $"Preview ready for '{armor.DisplayName}'.";
         }

--- a/Views/OutfitPreviewWindow.xaml
+++ b/Views/OutfitPreviewWindow.xaml
@@ -68,12 +68,26 @@
                            UseDefaultGestures="True" />
 
         <Border Grid.Row="2"
-                Background="#22000000"
-                Padding="12"
-                BorderThickness="0">
+                Background="{DynamicResource Brush.CardBackground}"
+                BorderBrush="{DynamicResource Brush.Border}"
+                BorderThickness="0,1,0,0"
+                Padding="12">
             <StackPanel>
+                <StackPanel x:Name="LoadingPanel"
+                            Margin="0,0,0,8"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center">
+                    <TextBlock Text="Loading preview..."
+                               FontSize="14"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource Brush.TextPrimary}"
+                               HorizontalAlignment="Center"
+                               Margin="0,4,0,4" />
+                </StackPanel>
+
                 <StackPanel x:Name="MissingAssetsPanel"
-                            Margin="0,0,0,8">
+                            Margin="0,0,0,8"
+                            Visibility="Collapsed">
                     <Border Background="#FFF3CD"
                             BorderBrush="#FFECB5"
                             BorderThickness="1"
@@ -174,16 +188,37 @@
                     </Grid>
                 </Expander>
 
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <Button Content="{lex:Loc Key={x:Static res:LocalizationKeys+Buttons.ResetView}}"
-                            Margin="0,0,8,0"
-                            Padding="14,6"
-                            Click="OnResetView" />
-                    <Button Content="{lex:Loc Key={x:Static res:LocalizationKeys+Buttons.Close}}"
-                            Padding="14,6"
-                            IsCancel="True"
-                            Click="OnClose" />
-                </StackPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                        <TextBlock Text="Gender:"
+                                   Margin="0,0,8,0"
+                                   VerticalAlignment="Center"
+                                   Foreground="{DynamicResource Brush.TextPrimary}" />
+                        <ComboBox x:Name="GenderComboBox"
+                                  Width="100"
+                                  SelectionChanged="OnGenderChanged"
+                                  ToolTip="Toggle with Tab key">
+                            <ComboBoxItem Content="Female" Tag="Female" />
+                            <ComboBoxItem Content="Male" Tag="Male" />
+                        </ComboBox>
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button Content="{lex:Loc Key={x:Static res:LocalizationKeys+Buttons.ResetView}}"
+                                Margin="0,0,8,0"
+                                Padding="14,6"
+                                Click="OnResetView" />
+                        <Button Content="{lex:Loc Key={x:Static res:LocalizationKeys+Buttons.Close}}"
+                                Padding="14,6"
+                                IsCancel="True"
+                                Click="OnClose" />
+                    </StackPanel>
+                </Grid>
             </StackPanel>
         </Border>
     </Grid>

--- a/Views/OutfitPreviewWindow.xaml.cs
+++ b/Views/OutfitPreviewWindow.xaml.cs
@@ -48,11 +48,7 @@ public sealed partial class OutfitPreviewWindow : IDisposable
     private float _keyFillMultiplier = 1.6f;
     private float _rimMultiplier = 1f;
     private int _currentSceneIndex;
-
-    public OutfitPreviewWindow(ArmorPreviewScene scene, ThemeService themeService)
-        : this(new ArmorPreviewSceneCollection(scene), themeService)
-    {
-    }
+    private GenderedModelVariant _currentGender;
 
     public OutfitPreviewWindow(ArmorPreviewSceneCollection sceneCollection, ThemeService themeService)
     {
@@ -60,19 +56,29 @@ public sealed partial class OutfitPreviewWindow : IDisposable
         _sceneCollection = sceneCollection ?? throw new ArgumentNullException(nameof(sceneCollection));
         _themeService = themeService;
         _currentSceneIndex = sceneCollection.InitialIndex;
+        _currentGender = sceneCollection.InitialGender;
 
         // Apply title bar theme
         SourceInitialized += (_, _) => _themeService.ApplyTitleBarTheme(this);
         _themeService.ThemeChanged += OnThemeChanged;
 
         InitializeViewport();
+        InitializeGenderDropdown();
         BuildScene();
+
+        // Add window-level keyboard shortcuts
+        PreviewKeyDown += OnWindowPreviewKeyDown;
     }
 
     private void OnThemeChanged(object? sender, bool isDark)
     {
         var hwnd = new WindowInteropHelper(this).Handle;
         ThemeService.ApplyTitleBarTheme(hwnd, isDark);
+    }
+
+    private void InitializeGenderDropdown()
+    {
+        GenderComboBox.SelectedIndex = _currentGender == GenderedModelVariant.Female ? 0 : 1;
     }
 
     private void InitializeViewport()
@@ -142,7 +148,13 @@ public sealed partial class OutfitPreviewWindow : IDisposable
 
     private async void BuildScene()
     {
-        var scene = await _sceneCollection.GetSceneAsync(_currentSceneIndex);
+        LoadingPanel.Visibility = Visibility.Visible;
+        MissingAssetsPanel.Visibility = Visibility.Collapsed;
+
+        var scene = await _sceneCollection.GetSceneAsync(_currentSceneIndex, _currentGender);
+
+        LoadingPanel.Visibility = Visibility.Collapsed;
+
         UpdateMetadataDisplay(_currentSceneIndex);
         UpdateMissingAssetsPanel(scene);
         RenderScene(scene);
@@ -540,6 +552,32 @@ public sealed partial class OutfitPreviewWindow : IDisposable
 
     private void OnClose(object sender, RoutedEventArgs e) => Close();
 
+    private void OnGenderChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+    {
+        if (GenderComboBox.SelectedItem is not System.Windows.Controls.ComboBoxItem selectedItem)
+            return;
+
+        var newGender = selectedItem.Tag?.ToString() == "Male"
+            ? GenderedModelVariant.Male
+            : GenderedModelVariant.Female;
+
+        if (newGender == _currentGender)
+            return;
+
+        _currentGender = newGender;
+        BuildScene();
+    }
+
+    private void ToggleGender()
+    {
+        _currentGender = _currentGender == GenderedModelVariant.Female
+            ? GenderedModelVariant.Male
+            : GenderedModelVariant.Female;
+
+        GenderComboBox.SelectedIndex = _currentGender == GenderedModelVariant.Female ? 0 : 1;
+        BuildScene();
+    }
+
     private void OnPreviousOutfit(object sender, RoutedEventArgs e) => NavigateOutfit(-1);
 
     private void OnNextOutfit(object sender, RoutedEventArgs e) => NavigateOutfit(1);
@@ -552,6 +590,34 @@ public sealed partial class OutfitPreviewWindow : IDisposable
         _currentSceneIndex = (_currentSceneIndex + direction + _sceneCollection.Count)
             % _sceneCollection.Count;
         BuildScene();
+    }
+
+    private void OnWindowPreviewKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.IsRepeat)
+            return;
+
+        if (e.Key == Key.Tab)
+        {
+            ToggleGender();
+            e.Handled = true;
+            return;
+        }
+
+        if (_sceneCollection.Count > 1)
+        {
+            switch (e.Key)
+            {
+                case Key.Left:
+                    NavigateOutfit(-1);
+                    e.Handled = true;
+                    break;
+                case Key.Right:
+                    NavigateOutfit(1);
+                    e.Handled = true;
+                    break;
+            }
+        }
     }
 
     private void OnViewportKeyDown(object sender, KeyEventArgs e)


### PR DESCRIPTION
Some more quality of life improvements for preview. Centered mostly on gender selection but also has some bonus fixes and perks.

### Changes
#### Preview Window UI:
- Added gender selection dropdown to preview footer
- Added Tab key shortcut to toggle gender
- Added Left/Right arrow key shortcuts for outfit navigation
- Added loading indicator that displays while previews build
- Applied dark mode styling to footer

#### Architecture:
- Migrated all preview implementations to factory pattern
- Added gender caching by (outfit index, gender) for better performance
- Removed pre-built scene functionality in favor of on-demand building

#### Smart Gender Defaults:
- NPCs tab: Previews open with the NPC's actual gender from game data
- Outfits tab distribution cards: Uses the associated NPC's gender
- Distribution Edit tab: Uses the distribution filter's gender setting (Male/Female/Any)
- Other contexts: Default to Female

### Technical Details
- `ArmorPreviewSceneCollection` now accepts `initialGender` parameter
- Added `GetNpcGender` helper that reads NPC configuration flags
- Preview scenes cached per (index, gender) combination

<img width="880" height="257" alt="image" src="https://github.com/user-attachments/assets/2aabc55d-f146-461c-a725-bf42b6f714fe" />
