### PR TITLE
Fix armor preview not rendering for some mods

### DIFF
--- a/Services/ArmorPreviewService.cs
+++ b/Services/ArmorPreviewService.cs
@@ -189,7 +189,7 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
         {
           _logger.Debug(
             "Skipping shape {ShapeName} in {FullPath} due to missing geometry or texture data.",
-            shape.Name?.ToString() ?? "<unnamed>",
+            shape.Name?.String ?? "<unnamed>",
             meshPath);
           continue;
         }
@@ -198,11 +198,11 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
         {
           _logger.Debug(
             "Skipping shape {ShapeName} because it has no diffuse texture.",
-            shape.Name?.ToString() ?? "<unnamed>");
+            shape.Name?.String ?? "<unnamed>");
           continue;
         }
 
-        var shapeName = shape.Name?.ToString();
+        var shapeName = shape.Name?.String;
         var name      = string.IsNullOrWhiteSpace(shapeName) ? partName : $"{partName} - {shapeName}";
         meshes.Add(
           new PreviewMeshShape(
@@ -238,14 +238,14 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
     var vertices = MeshUtilities.ExtractVertices(shape);
     if (vertices == null || vertices.Count == 0)
     {
-      _logger.Debug("Shape {ShapeName} has no vertices.", shape.Name?.ToString() ?? "<unnamed>");
+      _logger.Debug("Shape {ShapeName} has no vertices.", shape.Name?.String ?? "<unnamed>");
       return false;
     }
 
     var indices = MeshUtilities.ExtractIndices(shape);
     if (indices == null || indices.Count == 0)
     {
-      _logger.Debug("Shape {ShapeName} has no indices.", shape.Name?.ToString() ?? "<unnamed>");
+      _logger.Debug("Shape {ShapeName} has no indices.", shape.Name?.String ?? "<unnamed>");
       return false;
     }
 
@@ -259,7 +259,7 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
     else
     {
       normals = MeshUtilities.ComputeNormals(vertices, indices);
-      var shapeName = shape.Name?.ToString() ?? "<unnamed>";
+      var shapeName = shape.Name?.String ?? "<unnamed>";
       if (extractedNormals == null)
       {
         _logger.Debug("Shape {ShapeName} provided no normals; computed fallback.", shapeName);
@@ -279,7 +279,7 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
     {
       _logger.Debug(
         "Shape {ShapeName} texture coordinate count {TexCount} does not match vertex count {VertexCount}. Ignoring UVs.",
-        shape.Name?.ToString() ?? "<unnamed>",
+        shape.Name?.String ?? "<unnamed>",
         textureCoordinates.Count,
         vertices.Count);
       textureCoordinates = null;
@@ -288,7 +288,7 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
     {
       _logger.Debug(
         "Shape {ShapeName} extracted {TexCount} UV coordinates.",
-        shape.Name?.ToString() ?? "<unnamed>",
+        shape.Name?.String ?? "<unnamed>",
         textureCoordinates.Count);
     }
 
@@ -297,7 +297,7 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
 
     if (diffuse == null)
     {
-      _logger.Debug("Shape {ShapeName} has no diffuse texture.", shape.Name?.ToString() ?? "<unnamed>");
+      _logger.Debug("Shape {ShapeName} has no diffuse texture.", shape.Name?.String ?? "<unnamed>");
     }
 
     meshData = new MeshData(vertices, normals, textureCoordinates, indices, transform, diffuse);
@@ -312,7 +312,7 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
     GenderedModelVariant variant,
     ILinkCache? linkCache)
   {
-    var shapeName = shape.Name?.String ?? shape.Name?.ToString() ?? "<unnamed>";
+    var shapeName = shape.Name?.String ?? "<unnamed>";
 
     var alternateTexture = TryGetAlternateTexture(addon, variant, linkCache, shapeName);
     return alternateTexture ?? ExtractTextureFromNif(nif, shape, ownerModKey, shapeName);
@@ -385,11 +385,21 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
 
     CollectCandidates(nif.GetBlock<BSLightingShaderProperty>(shape.ShaderPropertyRef));
 
+    if (candidates.Count == 0)
+    {
+      CollectEffectShaderTexture(nif.GetBlock<BSEffectShaderProperty>(shape.ShaderPropertyRef), candidates);
+    }
+
     if (candidates.Count == 0 && shape.Properties != null)
     {
       foreach (var propRef in shape.Properties.References)
       {
         CollectCandidates(nif.GetBlock<BSLightingShaderProperty>(propRef));
+
+        if (candidates.Count == 0)
+        {
+          CollectEffectShaderTexture(nif.GetBlock<BSEffectShaderProperty>(propRef), candidates);
+        }
       }
     }
 
@@ -411,7 +421,7 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
       }
 
       var normalized = PathUtilities.NormalizeAssetPath(candidate);
-      var resolved   = assetLocator.ResolveAssetPath(normalized, ownerModKey);
+      var resolved   = ResolveTexturePath(normalized, ownerModKey);
       if (!string.IsNullOrWhiteSpace(resolved) && File.Exists(resolved))
       {
         _logger.Debug(
@@ -438,6 +448,44 @@ public class ArmorPreviewService(MutagenService mutagenService, GameAssetLocator
     }
 
     return null;
+  }
+
+  private static readonly System.Reflection.FieldInfo? EffectShaderSourceTextField =
+    typeof(BSEffectShaderProperty).GetField(
+      "_sourceTexture",
+      System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public);
+
+  private static void CollectEffectShaderTexture(BSEffectShaderProperty? effectShader, List<string> candidates)
+  {
+    if (effectShader == null || EffectShaderSourceTextField == null)
+    {
+      return;
+    }
+
+    if (EffectShaderSourceTextField.GetValue(effectShader) is string sourceTexture && sourceTexture.Length > 0)
+    {
+      candidates.Add(sourceTexture);
+    }
+  }
+
+  /// <summary>
+  /// Resolves a normalized texture path against the data folder, retrying with a
+  /// <c>textures/</c> prefix when the path is stored relative to that subdirectory.
+  /// </summary>
+  private string? ResolveTexturePath(string normalized, ModKey? ownerModKey)
+  {
+    var resolved = assetLocator.ResolveAssetPath(normalized, ownerModKey);
+    if (!string.IsNullOrWhiteSpace(resolved) && File.Exists(resolved))
+    {
+      return resolved;
+    }
+
+    if (!normalized.StartsWith("textures/", StringComparison.OrdinalIgnoreCase))
+    {
+      resolved = assetLocator.ResolveAssetPath("textures/" + normalized, ownerModKey);
+    }
+
+    return resolved;
   }
 
   private static (IModelGetter? Model, GenderedModelVariant Variant) SelectModel(

--- a/Utilities/MeshUtilities.cs
+++ b/Utilities/MeshUtilities.cs
@@ -198,22 +198,37 @@ public static class MeshUtilities
     }
 
     var set = nif.GetBlock<BSShaderTextureSet>(shader.TextureSetRef);
-    if (set?.Textures == null)
+    if (set == null)
     {
       yield break;
     }
 
-    foreach (var textureRef in set.Textures)
-    {
-      var path = textureRef?.Content;
-      if (string.IsNullOrWhiteSpace(path))
-      {
-        path = textureRef?.ToString();
-      }
+    var found = false;
 
-      if (!string.IsNullOrWhiteSpace(path))
+    if (set.Textures != null)
+    {
+      foreach (var textureRef in set.Textures)
       {
-        yield return path;
+        var path = textureRef?.Content;
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+          found = true;
+          yield return path;
+        }
+      }
+    }
+
+    // NiString4.Content can be null in some NIFs; fall back to StringRefs which
+    // uses NiStringRef and reliably populates the .String property.
+    if (!found)
+    {
+      foreach (var stringRef in set.StringRefs)
+      {
+        var path = stringRef?.String;
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+          yield return path;
+        }
       }
     }
   }


### PR DESCRIPTION
Was having issues rendering nifs for some mods (namely: Ophelia Accessories), decided to dig in and figure out why

### Summary
- Fix NiString4.Content returning null for some NIFs by falling back to BSShaderTextureSet.StringRefs, which reliably exposes texture paths via NiStringRef.String
- Handle NIFs that store texture paths relative to textures/ rather than the data root by retrying resolution with the prefix
- Add BSEffectShaderProperty support for mods using effect shaders (common in jewelry/glow meshes)
- Fix shape.Name?.ToString() returning the type name "NiflySharp.NiStringRef" instead of actual shape names