### PR TITLE
Remove distribution file auto-save and add rotating backups

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -44,6 +44,7 @@ public partial class App
     builder.RegisterType<ArmorPreviewService>().SingleInstance();
     builder.RegisterType<DistributionScannerService>().SingleInstance();
     builder.RegisterType<DistributionFileEditorService>().SingleInstance();
+    builder.RegisterType<DistributionFileBackupService>().SingleInstance();
     builder.RegisterType<NpcOutfitResolutionService>().SingleInstance();
     builder.RegisterType<KeywordDistributionResolver>().SingleInstance();
     builder.RegisterType<GameDataCacheService>().SingleInstance();

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -74,6 +74,8 @@ public partial class App
 
     Log.Information("Main window displayed.");
 
+    ShowOneTimeNotices(Container.Resolve<GuiSettingsService>(), Container.Resolve<IDialogService>());
+
     if (GuiSettingsService.Current?.AutoUpdateEnabled == true)
     {
       var dialogService = Container.Resolve<IDialogService>();
@@ -91,6 +93,25 @@ public partial class App
     Container?.Dispose();
     _loggingService?.Dispose();
     base.OnExit(e);
+  }
+
+  private static void ShowOneTimeNotices(GuiSettingsService settings, IDialogService dialog)
+  {
+    const string key = "autosave-removed-v1.13";
+    if (settings.HasDismissedNotice(key))
+    {
+      return;
+    }
+
+    dialog.ShowInfo(
+      "Auto-save for distribution files has been removed.\n\n" +
+      "Distribution files are now only saved when you explicitly click Save. " +
+      "A rotating backup is created automatically before each save, stored in:\n" +
+      "%LOCALAPPDATA%\\Boutique\\Backups\\\n\n" +
+      "This change prevents the silent data loss some users experienced with auto-save.",
+      "Distribution File Auto-Save Removed");
+
+    settings.DismissNotice(key);
   }
 
   private void ConfigureExceptionLogging()

--- a/Boutique.Tests/TestData/Spid/large_stress_test_DISTR.ini
+++ b/Boutique.Tests/TestData/Spid/large_stress_test_DISTR.ini
@@ -1,0 +1,595 @@
+;suppress inspection "DuplicateKeyInSection" for whole file
+; =============================================================================
+; Large SPID Stress-Test Distribution File
+; Exercises every form type, filter position, modifier, and edge case.
+; =============================================================================
+
+; =============================================================================
+; SECTION 1: Outfit Distributions — Basic
+; =============================================================================
+
+Outfit = DefaultFarmClothes|ActorTypeNPC
+Outfit = BanditHeavyOutfit|Bandit+ActorTypeNPC
+Outfit = BanditLightOutfit|*Bandit+-BanditChief
+Outfit = ForswornOutfit|Forsworn
+Outfit = WarlockOutfit|*Warlock,*Necromancer,*Conjurer
+Outfit = ThalmorOutfit|*Thalmor+ActorTypeNPC
+Outfit = ImperialLightOutfit|*Imperial+*Soldier+-*Officer
+Outfit = StormcloakOutfit|*Stormcloak+*Soldier
+Outfit = CompanionsOutfit|*Companion+-Kodlak+-Aela
+Outfit = ThievesGuildOutfit|*Thief,*Footpad,*Burglar
+Outfit = DarkBrotherhoodOutfit|*Assassin+DarkBrotherhood
+Outfit = NecromancerOutfit|*Necromancer,*Ritualist
+Outfit = VampireNobleOutfit|*VampireMaster,*VampireLord
+Outfit = DraugrOutfit|*Draugr+-*DraugrDeathlord
+Outfit = FalmerOutfit|*Falmer+-*FalmerWarmonger
+Outfit = DwemerServitorOutfit|*DwarvenCenturion,*DwarvenSphere
+Outfit = HunterOutfit|*Hunter+ActorTypeNPC
+
+; =============================================================================
+; SECTION 2: Outfit Distributions — FormID References
+; =============================================================================
+
+Outfit = 0x1396D~Skyrim.esm|ActorTypeNPC
+Outfit = 0xFE001800~CoolArmors.esp|*Guard
+Outfit = 0x800~NordWarfare.esp|NONE|NordRace
+Outfit = 0xD62~ElvenArmory.esp|NONE|HighElfRace+WoodElfRace
+Outfit = 0xA10~RequiemOutfits.esp|NONE|NONE|20/50
+Outfit = 0xB23~WarriorGear.esp|NONE|NONE|NONE|M
+Outfit = 0xC44~NobleAttire.esp|NONE|NONE|NONE|F/U
+Outfit = 0xD55~RogueWear.esp|*Thief|ThievesGuildFaction|10/30|M/-C|NONE|40
+
+; =============================================================================
+; SECTION 3: Outfit Distributions — Form Filters (Position 3)
+; =============================================================================
+
+Outfit = WhiterunGuardOutfit|NONE|CrimeFactionWhiterun
+Outfit = SolitudeGuardOutfit|NONE|CrimeFactionSolitude
+Outfit = RiftenGuardOutfit|NONE|CrimeFactionRift
+Outfit = WindhelmGuardOutfit|NONE|CrimeFactionEastmarch
+Outfit = MarkarthGuardOutfit|NONE|CrimeFactionReach
+Outfit = FalkreathGuardOutfit|NONE|CrimeFactionFalkreath
+Outfit = DawnstarGuardOutfit|NONE|CrimeFactionPale
+Outfit = MorthalGuardOutfit|NONE|CrimeFactionHjaalmarch
+Outfit = WinterholdGuardOutfit|NONE|CrimeFactionWinterhold
+
+Outfit = NordWarriorOutfit|NONE|NordRace+CrimeFactionWhiterun
+Outfit = DunmerMageOutfit|NONE|DarkElfRace+CollegeOfWinterholdFaction
+Outfit = OrcBerserkerOutfit|NONE|OrcRace+0x00048362~Skyrim.esm
+Outfit = BretonNobleOutfit|NONE|BretonRace+-BeggarFaction
+Outfit = RedguardScimitarOutfit|NONE|RedguardRace+-CrimeFactionWhiterun
+Outfit = ArgonianDockOutfit|NONE|ArgonianRace
+Outfit = KhajiitTraderOutfit|NONE|KhajiitRace
+
+Outfit = PluginFilteredOutfit|NONE|CoolNPCs.esp
+Outfit = MultiPluginOutfit|NONE|CoolNPCs.esp+MoreNPCs.esp
+
+; =============================================================================
+; SECTION 4: Outfit Distributions — Level Filters (Position 4)
+; =============================================================================
+
+Outfit = LowLevelBanditOutfit|*Bandit|NONE|1/10
+Outfit = MidLevelBanditOutfit|*Bandit|NONE|11/25
+Outfit = HighLevelBanditOutfit|*Bandit|NONE|26/50
+Outfit = EliteBanditOutfit|*BanditChief|NONE|50
+Outfit = MinLevelWarrior|NONE|NONE|30/
+Outfit = ExactLevelOutfit|NONE|NONE|25/25
+
+Outfit = DestructionMageOutfit|*Mage|NONE|14(50/100)
+Outfit = ConjurationMageOutfit|*Conjurer|NONE|13(60/100)
+Outfit = RestorationHealerOutfit|*Healer|NONE|16(40/75)
+Outfit = IllusionMageOutfit|*Warlock|NONE|15(55/999)
+Outfit = AlterationMageOutfit|*Wizard|NONE|12(30/60)
+Outfit = OneHandedFighterOutfit|*Fighter|NONE|6(50/100)
+Outfit = TwoHandedFighterOutfit|*Champion|NONE|7(60/100)
+Outfit = ArcheryHunterOutfit|*Hunter|NONE|8(40/80)
+Outfit = SneakThiefOutfit|*Thief|NONE|17(50/100)
+Outfit = SpeechMerchantOutfit|*Merchant|NONE|18(60/100)
+
+; =============================================================================
+; SECTION 5: Outfit Distributions — Trait Filters (Position 5)
+; =============================================================================
+
+Outfit = FemaleBanditOutfit|*Bandit|NONE|NONE|F
+Outfit = MaleBanditOutfit|*Bandit|NONE|NONE|M
+Outfit = UniqueNPCOutfit|NONE|NONE|NONE|U
+Outfit = GenericNPCOutfit|NONE|NONE|NONE|-U
+Outfit = SummonableOutfit|NONE|NONE|NONE|S
+Outfit = ChildOutfit|NONE|NONE|NONE|C
+Outfit = LeveledOutfit|NONE|NONE|NONE|L
+Outfit = TeammatOutfit|NONE|NONE|NONE|T
+Outfit = DeadNPCOutfit|NONE|NONE|NONE|D
+
+Outfit = FemaleUniqueOutfit|NONE|NONE|NONE|F/U
+Outfit = MaleNonUniqueOutfit|NONE|NONE|NONE|M/-U
+Outfit = FemaleAdultNonUniqueOutfit|NONE|NONE|NONE|F/-U/-C
+Outfit = MaleAdultLeveledOutfit|NONE|NONE|NONE|M/-C/L
+Outfit = FemaleNonSummonable|NONE|NONE|NONE|F/-S/-C
+
+; =============================================================================
+; SECTION 6: Outfit Distributions — Chance (Position 7)
+; =============================================================================
+
+Outfit = RareBanditOutfit|*Bandit|NONE|NONE|NONE|NONE|5
+Outfit = UncommonGuardOutfit|*Guard|NONE|NONE|NONE|NONE|15
+Outfit = FairChanceOutfit|*Soldier|NONE|NONE|NONE|NONE|25
+Outfit = CommonTraderOutfit|*Merchant|NONE|NONE|NONE|NONE|50
+Outfit = LikelyNobleOutfit|*Noble|NONE|NONE|NONE|NONE|75
+Outfit = AlmostCertainOutfit|ActorTypeNPC|NONE|NONE|NONE|NONE|95
+Outfit = GuaranteedOutfit|ActorTypeNPC|NONE|NONE|NONE|NONE|100
+
+; =============================================================================
+; SECTION 7: Outfit Distributions — Complex Combined Filters
+; =============================================================================
+
+Outfit = 1_Obi_Druchii|ActorTypeNPC|VampireFaction|NONE|F|NONE|5
+Outfit = EliteFemaleVampire|ActorTypeNPC+ActorTypeUndead|VampireFaction|30/50|F/U|NONE|10
+Outfit = NordGuardCaptainOutfit|*Guard+*Captain|NordRace+CrimeFactionWhiterun|20/|M/-C|NONE|100
+Outfit = DunmerWardenOutfit|*Warden,-*Prisoner|DarkElfRace+CrimeFactionRift|15/40|F/-U/-C|NONE|60
+Outfit = ImperialOfficerHeavy|*Officer+*Imperial+-*Recruit|ImperialRace|25/|M/U|NONE|80
+Outfit = ThalmorHighJusticiar|*Thalmor+*Justiciar|HighElfRace+ThalmorFaction|30/50|NONE|NONE|90
+Outfit = ForswornBriarheartOutfit|*Forsworn+*Briarheart|NONE|20/40|M|NONE|100
+Outfit = SilverHandOutfit|*SilverHand|CompanionsFaction|10/30|-U/M|NONE|50
+Outfit = PenitusOculatusOutfit|*Penitus+*Oculatus|NONE|NONE|M/-C|NONE|100
+Outfit = VigilantOutfit|*Vigilant+*Stendarr|NONE|15/|NONE|NONE|75
+
+Outfit = BanditEncounterA|*Bandit,*Thug,*Marauder|BanditFaction+-ForswornFaction|5/20|M/-U/-C|NONE|30
+Outfit = BanditEncounterB|*Bandit,*Thug,*Marauder|BanditFaction+-ForswornFaction|5/20|F/-U/-C|NONE|30
+Outfit = BanditEncounterC|*BanditChief,*BanditLeader|BanditFaction+-ForswornFaction|20/40|M/-C|NONE|50
+Outfit = BanditEncounterD|*BanditChief,*BanditLeader|BanditFaction+-ForswornFaction|20/40|F/-C|NONE|50
+
+; =============================================================================
+; SECTION 8: Keyword Distributions
+; =============================================================================
+
+Keyword = BTQ_isBandit|*Bandit,*Thug,*Marauder,*Outlaw
+Keyword = BTQ_isGuard|*Guard+ActorTypeNPC
+Keyword = BTQ_isMage|*Mage,*Conjurer,*Necromancer,*Warlock,*Wizard,*Sorcerer,*Pyromancer,*Cryomancer,*Electromancer
+Keyword = BTQ_isNoble|*Jarl,*Thane,*Noble,*Steward
+Keyword = BTQ_isVampire|NONE|VampireFaction
+Keyword = BTQ_isWerewolf|NONE|CompanionsFaction+WerewolfFaction
+Keyword = BTQ_isDawnguard|NONE|DawnguardFaction
+Keyword = BTQ_isThievesGuild|NONE|ThievesGuildFaction
+Keyword = BTQ_isDarkBrotherhood|NONE|DarkBrotherhoodFaction
+Keyword = BTQ_isCompanion|NONE|CompanionsFaction
+Keyword = BTQ_isCollegeMage|NONE|CollegeOfWinterholdFaction
+Keyword = BTQ_isImperialSoldier|*Imperial+*Soldier|ImperialLegionFaction
+Keyword = BTQ_isStormcloak|*Stormcloak|StormcloaksFaction
+Keyword = BTQ_isForsworn|*Forsworn|ForswornFaction
+
+Keyword = BTQ_isFemale|BTQ_isBandit|NONE|NONE|F/-U/-C
+Keyword = BTQ_isMale|BTQ_isBandit|NONE|NONE|M/-U/-C
+
+Keyword = BTQ_isHighLevel|NONE|NONE|40/
+Keyword = BTQ_isMidLevel|NONE|NONE|15/39
+Keyword = BTQ_isLowLevel|NONE|NONE|1/14
+
+Keyword = BTQ_isDestructionMaster|BTQ_isMage|NONE|14(85/999)
+Keyword = BTQ_isDestructionExpert|BTQ_isMage|NONE|14(65/84)
+Keyword = BTQ_isDestructionAdept|BTQ_isMage|NONE|14(45/64)
+Keyword = BTQ_isDestructionApprentice|BTQ_isMage|NONE|14(25/44)
+Keyword = BTQ_isDestructionNovice|BTQ_isMage|NONE|14(16/24)
+
+Keyword = BTQ_isConjurationMaster|BTQ_isMage|NONE|13(85/999)
+Keyword = BTQ_isConjurationExpert|BTQ_isMage|NONE|13(65/84)
+Keyword = BTQ_isConjurationAdept|BTQ_isMage|NONE|13(45/64)
+Keyword = BTQ_isConjurationApprentice|BTQ_isMage|NONE|13(25/44)
+Keyword = BTQ_isConjurationNovice|BTQ_isMage|NONE|13(16/24)
+
+Keyword = BTQ_isRestorationMaster|BTQ_isMage|NONE|16(85/999)
+Keyword = BTQ_isRestorationExpert|BTQ_isMage|NONE|16(65/84)
+Keyword = BTQ_isRestorationAdept|BTQ_isMage|NONE|16(45/64)
+Keyword = BTQ_isRestorationApprentice|BTQ_isMage|NONE|16(25/44)
+Keyword = BTQ_isRestorationNovice|BTQ_isMage|NONE|16(16/24)
+
+Keyword = BTQ_hasAnyMasterSkill|BTQ_isDestructionMaster,BTQ_isConjurationMaster,BTQ_isRestorationMaster
+Keyword = BTQ_hasAnyExpertSkill|BTQ_isDestructionExpert,BTQ_isConjurationExpert,BTQ_isRestorationExpert,BTQ_hasAnyMasterSkill
+
+Keyword = BTQ_GroupA|BTQ_isBandit+BTQ_isFemale|NONE|NONE|NONE|NONE|33
+Keyword = BTQ_GroupB|BTQ_isBandit+BTQ_isFemale,-BTQ_GroupA|NONE|NONE|NONE|NONE|50
+Keyword = BTQ_GroupC|BTQ_isBandit+BTQ_isFemale,-BTQ_GroupA,-BTQ_GroupB
+
+; =============================================================================
+; SECTION 9: Spell Distributions
+; =============================================================================
+
+Spell = 0x12FCD~Skyrim.esm|BTQ_isMage|NONE|NONE|NONE|NONE|50
+Spell = 0x1C789~Skyrim.esm|*Mage+ActorTypeNPC|NONE|25/50
+Spell = 0x2B456~Skyrim.esm|NONE|CollegeOfWinterholdFaction|30/
+Spell = FlameCloak|*Pyromancer|NONE|14(50/100)
+Spell = FrostCloak|*Cryomancer|NONE|14(50/100)
+Spell = LightningCloak|*Electromancer|NONE|14(50/100)
+Spell = ConjureDremora|*Conjurer|NONE|13(75/100)|NONE|NONE|25
+Spell = ConjureAtronachFlame|*Conjurer|NONE|13(25/50)
+Spell = ConjureAtronachFrost|*Conjurer|NONE|13(50/75)
+Spell = ConjureAtronachStorm|*Conjurer|NONE|13(75/100)
+Spell = SummonUndeadThrall|*Necromancer|NONE|13(85/100)|NONE|NONE|10
+Spell = ParalyzeSpell|*Mage|NONE|12(90/100)|NONE|NONE|5
+Spell = MassParalysis|*ArchMage|NONE|12(100/100)|NONE|NONE|1
+Spell = IronFleshSpell|*BattleMage|NONE|12(50/75)
+Spell = EbonyfleshSpell|*BattleMage|NONE|12(75/100)
+Spell = DragonhideSpell|*BattleMage|NONE|12(100/100)|NONE|NONE|5
+Spell = InvisibilitySpell|*Thief,*Assassin|NONE|15(75/100)
+Spell = MuffleSpell|*Thief,*Assassin|NONE|15(25/50)
+Spell = HealOtherSpell|*Healer,*Priest|NONE|16(40/60)
+Spell = GrandHealingSpell|*Healer,*Priest|NONE|16(75/100)
+Spell = TurnUndeadSpell|*Priest,*Vigilant|NONE|16(30/60)
+
+Spell = 0xABC01~Requiem.esp|BTQ_isHighLevel+BTQ_isMage|NONE|NONE|NONE|NONE|15
+Spell = 0xABC02~Requiem.esp|BTQ_isMidLevel+BTQ_isMage|NONE|NONE|NONE|NONE|30
+
+; =============================================================================
+; SECTION 10: Perk Distributions
+; =============================================================================
+
+Perk = SteelSmithing|*Blacksmith|NONE|NONE|NONE|NONE|80
+Perk = ArcaneBlacksmith|*Blacksmith|NONE|NONE|NONE|NONE|25
+Perk = DaedricSmithing|*Blacksmith|NONE|NONE|NONE|NONE|5
+Perk = DragonSmithing|*Blacksmith|NONE|NONE|NONE|NONE|3
+
+Perk = Armsman1|*Fighter,*Warrior,*Guard|NONE|1/15
+Perk = Armsman2|*Fighter,*Warrior,*Guard|NONE|15/30
+Perk = Armsman3|*Fighter,*Warrior,*Guard|NONE|30/50
+Perk = Armsman4|*Champion|NONE|50/75
+Perk = Armsman5|*Champion|NONE|75/
+
+Perk = Juggernaut1|*HeavyArmor+ActorTypeNPC|NONE|NONE|NONE|NONE|90
+Perk = Juggernaut2|*HeavyArmor+ActorTypeNPC|NONE|15/|NONE|NONE|70
+Perk = Juggernaut3|*HeavyArmor+ActorTypeNPC|NONE|30/|NONE|NONE|50
+Perk = WellFitted|*HeavyArmor+ActorTypeNPC|NONE|20/|NONE|NONE|40
+Perk = TowerOfStrength|*HeavyArmor+ActorTypeNPC|NONE|30/|NONE|NONE|30
+
+Perk = AgileDefender1|*LightArmor+ActorTypeNPC|NONE|NONE|NONE|NONE|90
+Perk = AgileDefender2|*LightArmor+ActorTypeNPC|NONE|15/|NONE|NONE|70
+Perk = AgileDefender3|*LightArmor+ActorTypeNPC|NONE|30/|NONE|NONE|50
+Perk = WindWalker|*LightArmor+ActorTypeNPC|NONE|40/|NONE|NONE|20
+
+Perk = Overdraw1|*Archer,*Hunter|NONE|NONE|NONE|NONE|90
+Perk = Overdraw2|*Archer,*Hunter|NONE|15/|NONE|NONE|70
+Perk = Overdraw3|*Archer,*Hunter|NONE|30/|NONE|NONE|50
+Perk = EagleEye|*Archer,*Hunter|NONE|20/|NONE|NONE|30
+Perk = SteadyHand1|*Archer,*Hunter|NONE|30/|NONE|NONE|40
+Perk = SteadyHand2|*Archer,*Hunter|NONE|40/|NONE|NONE|20
+Perk = PowerShot|*Archer,*Hunter|NONE|50/|NONE|NONE|25
+Perk = QuickShot|*Archer,*Hunter|NONE|60/|NONE|NONE|15
+
+Perk = LightFoot|*Thief,*Assassin,*Footpad|NONE|NONE|NONE|NONE|60
+Perk = SilentRoll|*Thief,*Assassin|NONE|20/|NONE|NONE|40
+Perk = Silence|*Assassin|NONE|40/|NONE|NONE|30
+Perk = ShadowWarrior|*Assassin|NONE|60/|NONE|NONE|10
+
+Perk = 0x1234A~Requiem.esp|*Bandit|NONE|10/20|NONE|NONE|50
+Perk = 0x1234B~Requiem.esp|*Bandit|NONE|20/35|NONE|NONE|40
+Perk = 0x1234C~Requiem.esp|*Bandit|NONE|35/50|NONE|NONE|30
+Perk = 0x1234D~Requiem.esp|*BanditChief|NONE|40/|NONE|NONE|60
+
+; =============================================================================
+; SECTION 11: Item Distributions
+; =============================================================================
+
+Item = IronSword|*Bandit|NONE|1/10|NONE|1
+Item = SteelSword|*Bandit|NONE|10/20|NONE|1
+Item = OrcishSword|*Bandit|NONE|20/30|NONE|1
+Item = DwarvenSword|*BanditChief|NONE|20/35|NONE|1
+Item = ElvenSword|*BanditChief|NONE|35/50|NONE|1
+Item = GlassSword|*BanditLeader|NONE|40/|NONE|1|10
+
+Item = 0x5ACE4~Skyrim.esm|*Blacksmith|NONE|NONE|NONE|5-15
+Item = 0x5ACE5~Skyrim.esm|*Blacksmith|NONE|NONE|NONE|3-8
+Item = 0x5AD93~Skyrim.esm|*Blacksmith|NONE|NONE|NONE|2-5
+Item = 0x5AD9E~Skyrim.esm|*Blacksmith|NONE|NONE|NONE|1-3|25
+
+Item = LockpickItem|*Thief,*Footpad,*Burglar|NONE|NONE|NONE|5-20
+Item = 0xF~Skyrim.esm|*Bandit,*Thug|NONE|NONE|NONE|10-100
+Item = 0xF~Skyrim.esm|*Noble,*Jarl,*Thane|NONE|NONE|NONE|100-500
+Item = 0xF~Skyrim.esm|*Merchant|NONE|NONE|NONE|200-1000
+
+Item = PotionofHealing|*Bandit,*Fighter,*Warrior|NONE|NONE|NONE|1-3|60
+Item = PotionofMagicka|*Mage,*Conjurer,*Necromancer|NONE|NONE|NONE|1-3|60
+Item = PotionofStamina|*Thief,*Assassin|NONE|NONE|NONE|1-2|50
+Item = PoisonofDamageHealth|*Assassin|NONE|NONE|NONE|1-2|30
+Item = PoisonofParalysis|*Assassin|NONE|30/|NONE|1|10
+
+Item = 0xA12BC~FoodOverhaul.esp|ActorTypeNPC+-ActorTypeUndead|NONE|NONE|NONE|1-3|80
+Item = 0xA12BD~FoodOverhaul.esp|ActorTypeNPC+-ActorTypeUndead|NONE|NONE|NONE|1-2|50
+Item = 0xA12BE~FoodOverhaul.esp|*Merchant|NONE|NONE|NONE|3-10
+
+; =============================================================================
+; SECTION 12: Shout Distributions
+; =============================================================================
+
+Shout = UnrelentingForce|*DraugrDeathlord|NONE|30/|NONE|NONE|50
+Shout = FrostBreath|*DraugrDeathlord|NONE|30/|NONE|NONE|30
+Shout = DisarmShout|*DraugrDeathlord|NONE|40/|NONE|NONE|20
+Shout = DrainVitality|NONE|VampireFaction|40/|U|NONE|10
+
+; =============================================================================
+; SECTION 13: Faction Distributions
+; =============================================================================
+
+Faction = CrimeFactionWhiterun|*WhiterunGuard
+Faction = CrimeFactionSolitude|*SolitudeGuard
+Faction = BanditFaction|*Bandit,*Thug,*Marauder,*Outlaw,*Highwayman
+Faction = BanditFriendFaction|*BanditAlly
+Faction = 0x00039F26~Skyrim.esm|*Merchant+*Whiterun|NONE|NONE|NONE|NONE|100
+
+; =============================================================================
+; SECTION 14: Skin Distributions
+; =============================================================================
+
+Skin = 0xAA001~VampireSkins.esp|NONE|VampireFaction|NONE|F|NONE|100
+Skin = 0xAA002~VampireSkins.esp|NONE|VampireFaction|NONE|M|NONE|100
+Skin = 0xBB001~BeastSkins.esp|NONE|WerewolfFaction
+Skin = 0xCC001~ArgonianSkins.esp|NONE|ArgonianRace|NONE|F
+Skin = 0xCC002~ArgonianSkins.esp|NONE|ArgonianRace|NONE|M
+Skin = 0xDD001~KhajiitSkins.esp|NONE|KhajiitRace
+
+; =============================================================================
+; SECTION 15: SleepOutfit Distributions
+; =============================================================================
+
+SleepOutfit = FarmClothesSleepOutfit|ActorTypeNPC+-ActorTypeUndead|NONE|NONE|-U/-C
+SleepOutfit = NobleSleepOutfit|*Jarl,*Thane,*Noble|NONE|NONE|U
+SleepOutfit = PrisonerSleepOutfit|NONE|PrisonerFaction
+SleepOutfit = 0xEE001~SleepwearMod.esp|ActorTypeNPC|NONE|NONE|F/-C|NONE|50
+SleepOutfit = 0xEE002~SleepwearMod.esp|ActorTypeNPC|NONE|NONE|M/-C|NONE|50
+SleepOutfit = VampireSleepOutfit|NONE|VampireFaction|NONE|NONE|NONE|100
+SleepOutfit = CompanionSleepOutfit|NONE|CompanionsFaction|NONE|T
+
+; =============================================================================
+; SECTION 16: Package Distributions
+; =============================================================================
+
+Package = 0xFF001~DailyRoutines.esp|*Blacksmith|NONE|NONE|NONE|0
+Package = 0xFF002~DailyRoutines.esp|*Merchant|NONE|NONE|NONE|0
+Package = 0xFF003~DailyRoutines.esp|*Innkeeper|NONE|NONE|NONE|0
+Package = 0xFF004~DailyRoutines.esp|*Guard|NONE|NONE|NONE|1
+Package = 0xFF005~DailyRoutines.esp|*Farmer|NONE|NONE|NONE|0
+Package = 0xFF006~DailyRoutines.esp|*Beggar|NONE|NONE|NONE|0
+Package = 0xFF007~DailyRoutines.esp|*Priest|NONE|NONE|NONE|0
+Package = 0xFF008~DailyRoutines.esp|*Bard|NONE|NONE|NONE|0|75
+
+; =============================================================================
+; SECTION 17: Exclusive Groups
+; =============================================================================
+
+ExclusiveGroup = BanditMeleeWeapon|IronSword,SteelSword,OrcishSword,DwarvenSword,ElvenSword,GlassSword
+ExclusiveGroup = BanditTier|BanditHeavyOutfit,BanditLightOutfit
+
+ExclusiveGroup = GuardCityOutfit|WhiterunGuardOutfit,SolitudeGuardOutfit,RiftenGuardOutfit,WindhelmGuardOutfit,MarkarthGuardOutfit,FalkreathGuardOutfit,DawnstarGuardOutfit,MorthalGuardOutfit,WinterholdGuardOutfit
+
+ExclusiveGroup = MageSchoolCloak|FlameCloak,FrostCloak,LightningCloak
+
+ExclusiveGroup = AtronachSummon|ConjureAtronachFlame,ConjureAtronachFrost,ConjureAtronachStorm
+
+ExclusiveGroup = VampireSkin|0xAA001~VampireSkins.esp,0xAA002~VampireSkins.esp
+
+ExclusiveGroup = EncounterOutfitMale|BanditEncounterA,BanditEncounterC
+ExclusiveGroup = EncounterOutfitFemale|BanditEncounterB,BanditEncounterD
+
+ExclusiveGroup = GuildMembership|BTQ_isThievesGuild,BTQ_isDarkBrotherhood,BTQ_isCompanion,BTQ_isCollegeMage
+
+ExclusiveGroup = PrimaryHealSpell|HealOtherSpell,GrandHealingSpell
+
+; Modify an existing group
+ExclusiveGroup = BanditMeleeWeapon|EbonySword,-IronSword
+
+; =============================================================================
+; SECTION 18: Tiered Outfit System with Keywords and Exclusive Groups
+; =============================================================================
+
+Keyword = BTQ_TierS|NONE|NONE|60/
+Keyword = BTQ_TierA|NONE|NONE|40/59
+Keyword = BTQ_TierB|NONE|NONE|20/39
+Keyword = BTQ_TierC|NONE|NONE|1/19
+
+Outfit = BTQ_BanditHeavyS|BTQ_isBandit+BTQ_TierS+BTQ_isMale|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_BanditHeavyA|BTQ_isBandit+BTQ_TierA+BTQ_isMale|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_BanditHeavyB|BTQ_isBandit+BTQ_TierB+BTQ_isMale|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_BanditHeavyC|BTQ_isBandit+BTQ_TierC+BTQ_isMale|NONE|NONE|NONE|NONE|100
+
+Outfit = BTQ_BanditLightS|BTQ_isBandit+BTQ_TierS+BTQ_isFemale|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_BanditLightA|BTQ_isBandit+BTQ_TierA+BTQ_isFemale|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_BanditLightB|BTQ_isBandit+BTQ_TierB+BTQ_isFemale|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_BanditLightC|BTQ_isBandit+BTQ_TierC+BTQ_isFemale|NONE|NONE|NONE|NONE|100
+
+ExclusiveGroup = TieredBanditMale|BTQ_BanditHeavyS,BTQ_BanditHeavyA,BTQ_BanditHeavyB,BTQ_BanditHeavyC
+ExclusiveGroup = TieredBanditFemale|BTQ_BanditLightS,BTQ_BanditLightA,BTQ_BanditLightB,BTQ_BanditLightC
+
+Outfit = BTQ_GuardEliteS|BTQ_isGuard+BTQ_TierS|NordRace|NONE|M/-C|NONE|100
+Outfit = BTQ_GuardEliteA|BTQ_isGuard+BTQ_TierA|NordRace|NONE|M/-C|NONE|100
+Outfit = BTQ_GuardEliteB|BTQ_isGuard+BTQ_TierB|NordRace|NONE|M/-C|NONE|100
+Outfit = BTQ_GuardEliteC|BTQ_isGuard+BTQ_TierC|NordRace|NONE|M/-C|NONE|100
+
+ExclusiveGroup = TieredNordGuardMale|BTQ_GuardEliteS,BTQ_GuardEliteA,BTQ_GuardEliteB,BTQ_GuardEliteC
+
+; =============================================================================
+; SECTION 19: Mage Specialization Outfits (Full Matrix)
+; =============================================================================
+
+Outfit = BTQ_MasterDestrFemA|BTQ_isFemale+BTQ_isMage+BTQ_isDestructionMaster+BTQ_GroupA
+Outfit = BTQ_MasterDestrFemB|BTQ_isFemale+BTQ_isMage+BTQ_isDestructionMaster+BTQ_GroupB
+Outfit = BTQ_MasterDestrFemC|BTQ_isFemale+BTQ_isMage+BTQ_isDestructionMaster+BTQ_GroupC
+Outfit = BTQ_ExpertDestrFemA|BTQ_isFemale+BTQ_isMage+BTQ_isDestructionExpert+BTQ_GroupA,-BTQ_hasAnyMasterSkill
+Outfit = BTQ_ExpertDestrFemB|BTQ_isFemale+BTQ_isMage+BTQ_isDestructionExpert+BTQ_GroupB,-BTQ_hasAnyMasterSkill
+Outfit = BTQ_ExpertDestrFemC|BTQ_isFemale+BTQ_isMage+BTQ_isDestructionExpert+BTQ_GroupC,-BTQ_hasAnyMasterSkill
+Outfit = BTQ_AdeptDestrFemA|BTQ_isFemale+BTQ_isMage+BTQ_isDestructionAdept+BTQ_GroupA,-BTQ_hasAnyExpertSkill
+Outfit = BTQ_AdeptDestrFemB|BTQ_isFemale+BTQ_isMage+BTQ_isDestructionAdept+BTQ_GroupB,-BTQ_hasAnyExpertSkill
+Outfit = BTQ_AdeptDestrFemC|BTQ_isFemale+BTQ_isMage+BTQ_isDestructionAdept+BTQ_GroupC,-BTQ_hasAnyExpertSkill
+
+Outfit = BTQ_MasterConjFemA|BTQ_isFemale+BTQ_isMage+BTQ_isConjurationMaster+BTQ_GroupA
+Outfit = BTQ_MasterConjFemB|BTQ_isFemale+BTQ_isMage+BTQ_isConjurationMaster+BTQ_GroupB
+Outfit = BTQ_MasterConjFemC|BTQ_isFemale+BTQ_isMage+BTQ_isConjurationMaster+BTQ_GroupC
+Outfit = BTQ_ExpertConjFemA|BTQ_isFemale+BTQ_isMage+BTQ_isConjurationExpert+BTQ_GroupA,-BTQ_hasAnyMasterSkill
+Outfit = BTQ_ExpertConjFemB|BTQ_isFemale+BTQ_isMage+BTQ_isConjurationExpert+BTQ_GroupB,-BTQ_hasAnyMasterSkill
+Outfit = BTQ_ExpertConjFemC|BTQ_isFemale+BTQ_isMage+BTQ_isConjurationExpert+BTQ_GroupC,-BTQ_hasAnyMasterSkill
+Outfit = BTQ_AdeptConjFemA|BTQ_isFemale+BTQ_isMage+BTQ_isConjurationAdept+BTQ_GroupA,-BTQ_hasAnyExpertSkill
+Outfit = BTQ_AdeptConjFemB|BTQ_isFemale+BTQ_isMage+BTQ_isConjurationAdept+BTQ_GroupB,-BTQ_hasAnyExpertSkill
+Outfit = BTQ_AdeptConjFemC|BTQ_isFemale+BTQ_isMage+BTQ_isConjurationAdept+BTQ_GroupC,-BTQ_hasAnyExpertSkill
+
+Outfit = BTQ_MasterRestFemA|BTQ_isFemale+BTQ_isMage+BTQ_isRestorationMaster+BTQ_GroupA
+Outfit = BTQ_MasterRestFemB|BTQ_isFemale+BTQ_isMage+BTQ_isRestorationMaster+BTQ_GroupB
+Outfit = BTQ_MasterRestFemC|BTQ_isFemale+BTQ_isMage+BTQ_isRestorationMaster+BTQ_GroupC
+Outfit = BTQ_ExpertRestFemA|BTQ_isFemale+BTQ_isMage+BTQ_isRestorationExpert+BTQ_GroupA,-BTQ_hasAnyMasterSkill
+Outfit = BTQ_ExpertRestFemB|BTQ_isFemale+BTQ_isMage+BTQ_isRestorationExpert+BTQ_GroupB,-BTQ_hasAnyMasterSkill
+Outfit = BTQ_ExpertRestFemC|BTQ_isFemale+BTQ_isMage+BTQ_isRestorationExpert+BTQ_GroupC,-BTQ_hasAnyMasterSkill
+Outfit = BTQ_AdeptRestFemA|BTQ_isFemale+BTQ_isMage+BTQ_isRestorationAdept+BTQ_GroupA,-BTQ_hasAnyExpertSkill
+Outfit = BTQ_AdeptRestFemB|BTQ_isFemale+BTQ_isMage+BTQ_isRestorationAdept+BTQ_GroupB,-BTQ_hasAnyExpertSkill
+Outfit = BTQ_AdeptRestFemC|BTQ_isFemale+BTQ_isMage+BTQ_isRestorationAdept+BTQ_GroupC,-BTQ_hasAnyExpertSkill
+
+; =============================================================================
+; SECTION 20: Named NPC Targeting (String Filters with Exact + Partial)
+; =============================================================================
+
+Outfit = BalgruufRobes|Balgruuf
+Outfit = UlfricArmor|Ulfric
+Outfit = ElisifGown|Elisif
+Outfit = SeranaVampireOutfit|Serana|VampireFaction
+Outfit = HarkonRoyal|Harkon|VampireFaction|NONE|M
+Outfit = GeneralTulliusArmor|GeneralTullius|NONE|NONE|M/U
+Outfit = GalmarStoneFistArmor|GalmarStoneFist|NONE|NONE|M/U
+Outfit = 0x13BAF~Skyrim.esm|Elenwen|ThalmorFaction|NONE|F/U
+Outfit = DelphineArmor|Delphine|NONE|NONE|F/U
+Outfit = AelaHuntressOutfit|Aela|CompanionsFaction|NONE|F/U
+Outfit = MjollLionessArmor|MjolltheLioness|NONE|NONE|F/U
+Outfit = JZargoRobes|J'zargo|CollegeOfWinterholdFaction|NONE|M/U
+Outfit = BrelynaMaryonRobes|BrelynaMeryon|CollegeOfWinterholdFaction|NONE|F/U
+Outfit = OnmundRobes|Onmund|CollegeOfWinterholdFaction|NONE|M/U
+
+Outfit = AllJarls|Balgruuf,Ulfric,Elisif,Igmund,Laila,Korir,Skald,Idgrod,Siddgeir
+Outfit = AllHousecarlOutfit|*Housecarl+ActorTypeNPC|NONE|NONE|U
+
+; =============================================================================
+; SECTION 21: Multi-Plugin OR Combinations
+; =============================================================================
+
+Outfit = 0xA01~WarriorArmors.esp|*Warrior,*Champion,*Knight
+Outfit = 0xA02~WarriorArmors.esp|*Fighter,*Gladiator,*Berserker
+Outfit = 0xA03~WarriorArmors.esp|*Soldier,*Legionnaire,*Centurion
+Outfit = 0xA04~MageRobes.esp|*Mage,*Wizard,*Sorcerer,*Conjurer,*Necromancer,*Warlock
+Outfit = 0xA05~MageRobes.esp|*Pyromancer,*Cryomancer,*Electromancer,*Elementalist
+Outfit = 0xA06~ThiefGear.esp|*Thief,*Footpad,*Burglar,*Bandit,*Rogue
+Outfit = 0xA07~ThiefGear.esp|*Assassin,*Nightblade,*Shadowfoot
+
+; =============================================================================
+; SECTION 22: Edge Cases and Special Syntax
+; =============================================================================
+
+Outfit = MinimalOutfit|ActorTypeNPC
+Outfit = JustChance|NONE|NONE|NONE|NONE|NONE|1
+Outfit = JustTraits|NONE|NONE|NONE|F/U/-C
+Outfit = JustLevel|NONE|NONE|30/50
+Outfit = JustFormFilter|NONE|NordRace
+Outfit = EveryFilterUsed|*Guard+ActorTypeNPC+-*Stormcloak|NordRace+CrimeFactionWhiterun+-DawnguardFaction|20/40|M/-U/-C|NONE|75
+
+Keyword = EmptyFilterKeyword|NONE|NONE|NONE|NONE|NONE|50
+Keyword = AllNONEKeyword|NONE|NONE|NONE|NONE
+
+Outfit = PartialWildcardStart|*Guard
+Outfit = PartialWildcardEnd|Guard*
+Outfit = PartialWildcardBoth|*Guard*
+Outfit = ExcludePartial|-*Bandit
+Outfit = CombineAndExclude|ActorTypeNPC+*Guard+-*Stormcloak+-*Thalmor
+
+Outfit = ORFilterOutfit|Bandit,Thug,Marauder,Outlaw,Highwayman,Rogue,Cutpurse,Footpad
+Outfit = ANDFilterOutfit|ActorTypeNPC+Bandit+ActorTypeGhost
+Outfit = MixedORAndAND|ActorTypeNPC+Bandit,ActorTypeNPC+Thug,ActorTypeNPC+Marauder
+
+; Plugin as form filter
+Outfit = PluginOnlyFilter|NONE|CoolNPCs.esp
+Outfit = PluginPlusRace|NONE|CoolNPCs.esp+NordRace
+
+; Very long string filter chain
+Keyword = BTQ_isWildNPC|*Wolf,*Bear,*Sabrecat,*Spider,*Skeever,*Mudcrab,*Horker,*Fox,*Hawk,*Goat,*Cow,*Deer,*Elk,*Rabbit,*Chicken,*Dog
+
+; =============================================================================
+; SECTION 23: Holdout Force-Equip Patterns
+; =============================================================================
+
+Outfit = WhiterunDayGuard|BTQ_isGuard|CrimeFactionWhiterun|NONE|M/-C|NONE|100
+Outfit = WhiterunNightGuard|BTQ_isGuard|CrimeFactionWhiterun|NONE|M/-C|NONE|100
+Outfit = SolitudeDayGuard|BTQ_isGuard|CrimeFactionSolitude|NONE|M/-C|NONE|100
+Outfit = SolitudeNightGuard|BTQ_isGuard|CrimeFactionSolitude|NONE|M/-C|NONE|100
+Outfit = RiftenDayGuard|BTQ_isGuard|CrimeFactionRift|NONE|M/-C|NONE|100
+Outfit = RiftenNightGuard|BTQ_isGuard|CrimeFactionRift|NONE|M/-C|NONE|100
+Outfit = WindhelmDayGuard|BTQ_isGuard|CrimeFactionEastmarch|NONE|M/-C|NONE|100
+Outfit = WindhelmNightGuard|BTQ_isGuard|CrimeFactionEastmarch|NONE|M/-C|NONE|100
+Outfit = MarkarthDayGuard|BTQ_isGuard|CrimeFactionReach|NONE|M/-C|NONE|100
+Outfit = MarkarthNightGuard|BTQ_isGuard|CrimeFactionReach|NONE|M/-C|NONE|100
+
+ExclusiveGroup = WhiterunGuardDuty|WhiterunDayGuard,WhiterunNightGuard
+ExclusiveGroup = SolitudeGuardDuty|SolitudeDayGuard,SolitudeNightGuard
+ExclusiveGroup = RiftenGuardDuty|RiftenDayGuard,RiftenNightGuard
+ExclusiveGroup = WindhelmGuardDuty|WindhelmDayGuard,WindhelmNightGuard
+ExclusiveGroup = MarkarthGuardDuty|MarkarthDayGuard,MarkarthNightGuard
+
+; =============================================================================
+; SECTION 24: High-Volume Keyword Cascade (Stress Test for Parser)
+; =============================================================================
+
+Keyword = BTQ_RegionWhiterun|NONE|CrimeFactionWhiterun
+Keyword = BTQ_RegionSolitude|NONE|CrimeFactionSolitude
+Keyword = BTQ_RegionRiften|NONE|CrimeFactionRift
+Keyword = BTQ_RegionWindhelm|NONE|CrimeFactionEastmarch
+Keyword = BTQ_RegionMarkarth|NONE|CrimeFactionReach
+Keyword = BTQ_RegionFalkreath|NONE|CrimeFactionFalkreath
+Keyword = BTQ_RegionDawnstar|NONE|CrimeFactionPale
+Keyword = BTQ_RegionMorthal|NONE|CrimeFactionHjaalmarch
+Keyword = BTQ_RegionWinterhold|NONE|CrimeFactionWinterhold
+
+Keyword = BTQ_RaceNord|NONE|NordRace
+Keyword = BTQ_RaceImperial|NONE|ImperialRace
+Keyword = BTQ_RaceBreton|NONE|BretonRace
+Keyword = BTQ_RaceRedguard|NONE|RedguardRace
+Keyword = BTQ_RaceDunmer|NONE|DarkElfRace
+Keyword = BTQ_RaceAltmer|NONE|HighElfRace
+Keyword = BTQ_RaceBosmer|NONE|WoodElfRace
+Keyword = BTQ_RaceOrc|NONE|OrcRace
+Keyword = BTQ_RaceArgonian|NONE|ArgonianRace
+Keyword = BTQ_RaceKhajiit|NONE|KhajiitRace
+
+Keyword = BTQ_NordMaleBandit|BTQ_RaceNord+BTQ_isBandit|NONE|NONE|M/-U/-C
+Keyword = BTQ_NordFemaleBandit|BTQ_RaceNord+BTQ_isBandit|NONE|NONE|F/-U/-C
+Keyword = BTQ_ImperialMaleBandit|BTQ_RaceImperial+BTQ_isBandit|NONE|NONE|M/-U/-C
+Keyword = BTQ_ImperialFemaleBandit|BTQ_RaceImperial+BTQ_isBandit|NONE|NONE|F/-U/-C
+Keyword = BTQ_BretonMaleBandit|BTQ_RaceBreton+BTQ_isBandit|NONE|NONE|M/-U/-C
+Keyword = BTQ_BretonFemaleBandit|BTQ_RaceBreton+BTQ_isBandit|NONE|NONE|F/-U/-C
+Keyword = BTQ_RedguardMaleBandit|BTQ_RaceRedguard+BTQ_isBandit|NONE|NONE|M/-U/-C
+Keyword = BTQ_RedguardFemaleBandit|BTQ_RaceRedguard+BTQ_isBandit|NONE|NONE|F/-U/-C
+Keyword = BTQ_DunmerMaleBandit|BTQ_RaceDunmer+BTQ_isBandit|NONE|NONE|M/-U/-C
+Keyword = BTQ_DunmerFemaleBandit|BTQ_RaceDunmer+BTQ_isBandit|NONE|NONE|F/-U/-C
+Keyword = BTQ_AltmerMaleBandit|BTQ_RaceAltmer+BTQ_isBandit|NONE|NONE|M/-U/-C
+Keyword = BTQ_AltmerFemaleBandit|BTQ_RaceAltmer+BTQ_isBandit|NONE|NONE|F/-U/-C
+Keyword = BTQ_BosmerMaleBandit|BTQ_RaceBosmer+BTQ_isBandit|NONE|NONE|M/-U/-C
+Keyword = BTQ_BosmerFemaleBandit|BTQ_RaceBosmer+BTQ_isBandit|NONE|NONE|F/-U/-C
+Keyword = BTQ_OrcMaleBandit|BTQ_RaceOrc+BTQ_isBandit|NONE|NONE|M/-U/-C
+Keyword = BTQ_OrcFemaleBandit|BTQ_RaceOrc+BTQ_isBandit|NONE|NONE|F/-U/-C
+Keyword = BTQ_ArgonianMaleBandit|BTQ_RaceArgonian+BTQ_isBandit|NONE|NONE|M/-U/-C
+Keyword = BTQ_ArgonianFemaleBandit|BTQ_RaceArgonian+BTQ_isBandit|NONE|NONE|F/-U/-C
+Keyword = BTQ_KhajiitMaleBandit|BTQ_RaceKhajiit+BTQ_isBandit|NONE|NONE|M/-U/-C
+Keyword = BTQ_KhajiitFemaleBandit|BTQ_RaceKhajiit+BTQ_isBandit|NONE|NONE|F/-U/-C
+
+; Race-specific bandit outfits
+Outfit = BTQ_NordMaleBanditOutfit|BTQ_NordMaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_NordFemaleBanditOutfit|BTQ_NordFemaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_ImperialMaleBanditOutfit|BTQ_ImperialMaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_ImperialFemaleBanditOutfit|BTQ_ImperialFemaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_BretonMaleBanditOutfit|BTQ_BretonMaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_BretonFemaleBanditOutfit|BTQ_BretonFemaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_RedguardMaleBanditOutfit|BTQ_RedguardMaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_RedguardFemaleBanditOutfit|BTQ_RedguardFemaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_DunmerMaleBanditOutfit|BTQ_DunmerMaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_DunmerFemaleBanditOutfit|BTQ_DunmerFemaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_AltmerMaleBanditOutfit|BTQ_AltmerMaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_AltmerFemaleBanditOutfit|BTQ_AltmerFemaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_BosmerMaleBanditOutfit|BTQ_BosmerMaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_BosmerFemaleBanditOutfit|BTQ_BosmerFemaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_OrcMaleBanditOutfit|BTQ_OrcMaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_OrcFemaleBanditOutfit|BTQ_OrcFemaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_ArgonianMaleBanditOutfit|BTQ_ArgonianMaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_ArgonianFemaleBanditOutfit|BTQ_ArgonianFemaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_KhajiitMaleBanditOutfit|BTQ_KhajiitMaleBandit|NONE|NONE|NONE|NONE|100
+Outfit = BTQ_KhajiitFemaleBanditOutfit|BTQ_KhajiitFemaleBandit|NONE|NONE|NONE|NONE|100
+
+ExclusiveGroup = RaceBanditMale|BTQ_NordMaleBanditOutfit,BTQ_ImperialMaleBanditOutfit,BTQ_BretonMaleBanditOutfit,BTQ_RedguardMaleBanditOutfit,BTQ_DunmerMaleBanditOutfit,BTQ_AltmerMaleBanditOutfit,BTQ_BosmerMaleBanditOutfit,BTQ_OrcMaleBanditOutfit,BTQ_ArgonianMaleBanditOutfit,BTQ_KhajiitMaleBanditOutfit
+ExclusiveGroup = RaceBanditFemale|BTQ_NordFemaleBanditOutfit,BTQ_ImperialFemaleBanditOutfit,BTQ_BretonFemaleBanditOutfit,BTQ_RedguardFemaleBanditOutfit,BTQ_DunmerFemaleBanditOutfit,BTQ_AltmerFemaleBanditOutfit,BTQ_BosmerFemaleBanditOutfit,BTQ_OrcFemaleBanditOutfit,BTQ_ArgonianFemaleBanditOutfit,BTQ_KhajiitFemaleBanditOutfit

--- a/Services/DistributionFileBackupService.cs
+++ b/Services/DistributionFileBackupService.cs
@@ -1,0 +1,123 @@
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Serilog;
+
+namespace Boutique.Services;
+
+public record DistributionBackupInfo(string FilePath, DateTime CreatedUtc, long SizeBytes);
+
+/// <summary>
+///   Creates rotating, on-disk backups of distribution files before they are overwritten.
+///   Backups are stored under %LOCALAPPDATA%\Boutique\Backups\ — outside the user's Skyrim
+///   Data tree — so they survive MO2/Vortex virtual filesystem writes and are not picked up
+///   by SPID / SkyPatcher's load scanner.
+/// </summary>
+public class DistributionFileBackupService
+{
+  public const int MaxBackupsPerFile = 15;
+
+  private static readonly string BackupRoot = Path.Combine(
+    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+    "Boutique",
+    "Backups");
+
+  private readonly ILogger _logger;
+
+  public DistributionFileBackupService(ILogger logger) =>
+    _logger = logger.ForContext<DistributionFileBackupService>();
+
+  /// <summary>
+  ///   Copies the current contents of <paramref name="filePath" /> into a timestamped backup,
+  ///   then prunes the backup directory down to <see cref="MaxBackupsPerFile" /> entries.
+  ///   Never throws — backup failures must not block the user's save.
+  /// </summary>
+  public void CreateBackup(string filePath)
+  {
+    if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath))
+    {
+      return;
+    }
+
+    try
+    {
+      var backupDir = GetBackupDirectory(filePath);
+      Directory.CreateDirectory(backupDir);
+
+      var timestamp  = DateTime.UtcNow.ToString("yyyyMMdd_HHmmssfff", CultureInfo.InvariantCulture);
+      var backupName = $"{Path.GetFileName(filePath)}.{timestamp}.bak";
+      var backupPath = Path.Combine(backupDir, backupName);
+
+      File.Copy(filePath, backupPath, overwrite: false);
+      _logger.Debug("Created backup: {BackupPath}", backupPath);
+
+      PruneOldBackups(backupDir);
+    }
+    catch (Exception ex)
+    {
+      _logger.Warning(ex, "Failed to create backup for {Path}", filePath);
+    }
+  }
+
+  public IReadOnlyList<DistributionBackupInfo> ListBackups(string filePath)
+  {
+    if (string.IsNullOrWhiteSpace(filePath))
+    {
+      return [];
+    }
+
+    var dir = GetBackupDirectory(filePath);
+    if (!Directory.Exists(dir))
+    {
+      return [];
+    }
+
+    return new DirectoryInfo(dir)
+           .EnumerateFiles("*.bak")
+           .OrderByDescending(f => f.CreationTimeUtc)
+           .Select(f => new DistributionBackupInfo(f.FullName, f.CreationTimeUtc, f.Length))
+           .ToList();
+  }
+
+  /// <summary>
+  ///   Returns the per-file backup directory. Scheme: <c>&lt;filename&gt;_&lt;shortHash&gt;</c>
+  ///   inside the global backup root. The filename component is human-readable; the hash
+  ///   disambiguates same-named files living in different paths (e.g. two mods each shipping
+  ///   a <c>Boutique_Distribution.ini</c>).
+  /// </summary>
+  public static string GetBackupDirectory(string filePath)
+  {
+    var shortHash  = ShortHashOfPath(filePath);
+    var safeName   = Path.GetFileName(filePath);
+    var folderName = $"{safeName}_{shortHash}";
+    return Path.Combine(BackupRoot, folderName);
+  }
+
+  private void PruneOldBackups(string backupDir)
+  {
+    var backups = new DirectoryInfo(backupDir)
+                  .EnumerateFiles("*.bak")
+                  .OrderByDescending(f => f.CreationTimeUtc)
+                  .ToList();
+
+    foreach (var stale in backups.Skip(MaxBackupsPerFile))
+    {
+      try
+      {
+        stale.Delete();
+      }
+      catch (Exception ex)
+      {
+        _logger.Debug(ex, "Failed to prune stale backup {File}", stale.FullName);
+      }
+    }
+  }
+
+  private static string ShortHashOfPath(string filePath)
+  {
+    var normalized = filePath.ToLowerInvariant();
+    var bytes      = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+    return Convert.ToHexString(bytes).Substring(0, 8).ToLowerInvariant();
+  }
+}

--- a/Services/GuiSettingsService.cs
+++ b/Services/GuiSettingsService.cs
@@ -33,6 +33,7 @@ public class GuiSettings
   public Dictionary<string, double>? GridSplitterPositions { get; set; }
   public Dictionary<string, SecondaryWindowGeometry>? SecondaryWindowGeometries { get; set; }
   public Dictionary<string, OutfitDraftsState>? OutfitDraftsStates { get; set; }
+  public HashSet<string>? DismissedNotices { get; set; }
 }
 
 public class OutfitDraftsState
@@ -338,6 +339,18 @@ public class GuiSettingsService
                     : state.Collapsed.Remove(editorId);
 
     if (changed)
+    {
+      SaveSettings();
+    }
+  }
+
+  public bool HasDismissedNotice(string noticeKey) =>
+    _settings.DismissedNotices?.Contains(noticeKey) == true;
+
+  public void DismissNotice(string noticeKey)
+  {
+    _settings.DismissedNotices ??= [];
+    if (_settings.DismissedNotices.Add(noticeKey))
     {
       SaveSettings();
     }

--- a/ViewModels/DistributionEditTabViewModel.FileOperations.cs
+++ b/ViewModels/DistributionEditTabViewModel.FileOperations.cs
@@ -89,6 +89,7 @@ public sealed partial class DistributionEditTabViewModel
         Directory.CreateDirectory(directory);
       }
 
+      _backupService.CreateBackup(finalFilePath);
       await File.WriteAllTextAsync(finalFilePath, DistributionFileContent, Encoding.UTF8);
       _lastSavedContent = DistributionFileContent;
 
@@ -131,6 +132,7 @@ public sealed partial class DistributionEditTabViewModel
       case true:
         if (!IsCreatingNewFile && File.Exists(DistributionFilePath))
         {
+          _backupService.CreateBackup(DistributionFilePath);
           File.WriteAllText(DistributionFilePath, DistributionFileContent, Encoding.UTF8);
           _lastSavedContent = DistributionFileContent;
           _logger.Information("Saved distribution file: {Path}", DistributionFilePath);
@@ -147,29 +149,6 @@ public sealed partial class DistributionEditTabViewModel
         return true;
       default:
         return false;
-    }
-  }
-
-  private void AutoSaveFile(string content)
-  {
-    try
-    {
-      var path = DistributionFilePath;
-      if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
-      {
-        return;
-      }
-
-      File.WriteAllText(path, content, Encoding.UTF8);
-      _lastSavedContent                     = content;
-      _guiSettings.LastDistributionFilePath = path;
-      _logger.Debug("Auto-saved distribution file: {Path}", path);
-
-      Application.Current?.Dispatcher.BeginInvoke(() => ShowAutoSaveIndicator = true);
-    }
-    catch (Exception ex)
-    {
-      _logger.Warning(ex, "Auto-save failed for {Path}", DistributionFilePath);
     }
   }
 

--- a/ViewModels/DistributionEditTabViewModel.cs
+++ b/ViewModels/DistributionEditTabViewModel.cs
@@ -30,6 +30,7 @@ public class PreviewLine
 public sealed partial class DistributionEditTabViewModel : ReactiveObject, IDisposable
 {
   private readonly ArmorPreviewService                                 _armorPreviewService;
+  private readonly DistributionFileBackupService                       _backupService;
   private readonly GameDataCacheService                                _cache;
   private readonly IObservable<bool>                                   _canPaste;
   private readonly IObservable<bool>                                   _canSave;
@@ -140,8 +141,6 @@ public sealed partial class DistributionEditTabViewModel : ReactiveObject, IDisp
 
   [Reactive] private string _raceSearchText = string.Empty;
 
-  [Reactive] private bool _showAutoSaveIndicator;
-
   [Reactive] private string _statusMessage = string.Empty;
 
   [Reactive] private string _suggestedFileName = string.Empty;
@@ -155,6 +154,7 @@ public sealed partial class DistributionEditTabViewModel : ReactiveObject, IDisp
     GuiSettingsService guiSettings,
     DistributionEntryHydrationService hydrationService,
     DistributionFilePathService filePathService,
+    DistributionFileBackupService backupService,
     IDialogService dialogService,
     ILogger logger)
   {
@@ -166,6 +166,7 @@ public sealed partial class DistributionEditTabViewModel : ReactiveObject, IDisp
     _guiSettings         = guiSettings;
     _hydrationService    = hydrationService;
     _filePathService     = filePathService;
+    _backupService       = backupService;
     _dialogService       = dialogService;
     _logger              = logger.ForContext<DistributionEditTabViewModel>();
 
@@ -229,23 +230,6 @@ public sealed partial class DistributionEditTabViewModel : ReactiveObject, IDisp
         .Throttle(TimeSpan.FromMilliseconds(100))
         .ObserveOn(RxApp.TaskpoolScheduler)
         .Subscribe(entry => UpdateMatchingNpcsForEntry(entry));
-
-    _disposables.Add(
-      this.WhenAnyValue(vm => vm.DistributionFileContent)
-          .Skip(1)
-          .Where(_ => !_isBulkLoading && !IsLoading && !IsCreatingNewFile)
-          .Where(_ => !string.IsNullOrWhiteSpace(DistributionFilePath) && File.Exists(DistributionFilePath))
-          .Throttle(TimeSpan.FromMilliseconds(100))
-          .Where(content => content != _lastSavedContent)
-          .ObserveOn(RxApp.TaskpoolScheduler)
-          .Subscribe(content => AutoSaveFile(content)));
-
-    _disposables.Add(
-      this.WhenAnyValue(vm => vm.ShowAutoSaveIndicator)
-          .Where(show => show)
-          .Delay(TimeSpan.FromSeconds(2))
-          .ObserveOn(RxApp.MainThreadScheduler)
-          .Subscribe(_ => ShowAutoSaveIndicator = false));
   }
 
   public ReadOnlyObservableCollection<ClassRecordViewModel> FilteredClasses { get; private set; } = null!;

--- a/ViewModels/DistributionViewModel.cs
+++ b/ViewModels/DistributionViewModel.cs
@@ -41,6 +41,7 @@ public partial class DistributionViewModel : ReactiveObject
     GuiSettingsService guiSettings,
     DistributionEntryHydrationService hydrationService,
     DistributionFilePathService filePathService,
+    DistributionFileBackupService backupService,
     IDialogService dialogService,
     ILogger logger)
   {
@@ -61,6 +62,7 @@ public partial class DistributionViewModel : ReactiveObject
       guiSettings,
       hydrationService,
       filePathService,
+      backupService,
       dialogService,
       logger);
 

--- a/Views/DistributionEntryListView.xaml
+++ b/Views/DistributionEntryListView.xaml
@@ -175,32 +175,6 @@
                 Command="{Binding AddDistributionEntryCommand}" Margin="0,0,6,0" Padding="8,2" />
         <Button Content="{lex:Loc Key={x:Static res:LocalizationKeys+Distribution.SaveFile}}"
                 Command="{Binding SaveDistributionFileCommand}" Margin="0,0,6,0" Padding="8,2" />
-        <TextBlock Text="Saved" VerticalAlignment="Center" Margin="0,0,6,0" FontSize="11"
-                   Foreground="{StaticResource Brush.Accent}">
-          <TextBlock.Style>
-            <Style TargetType="TextBlock">
-              <Setter Property="Opacity" Value="0" />
-              <Style.Triggers>
-                <DataTrigger Binding="{Binding ShowAutoSaveIndicator}" Value="True">
-                  <DataTrigger.EnterActions>
-                    <BeginStoryboard>
-                      <Storyboard>
-                        <DoubleAnimation Storyboard.TargetProperty="Opacity" To="1" Duration="0:0:0.15" />
-                      </Storyboard>
-                    </BeginStoryboard>
-                  </DataTrigger.EnterActions>
-                  <DataTrigger.ExitActions>
-                    <BeginStoryboard>
-                      <Storyboard>
-                        <DoubleAnimation Storyboard.TargetProperty="Opacity" To="0" Duration="0:0:0.5" />
-                      </Storyboard>
-                    </BeginStoryboard>
-                  </DataTrigger.ExitActions>
-                </DataTrigger>
-              </Style.Triggers>
-            </Style>
-          </TextBlock.Style>
-        </TextBlock>
         <Button Content="{lex:Loc Key={x:Static res:LocalizationKeys+Distribution.PasteFilter}}"
                 Command="{Binding PasteFilterToEntryCommand}" Padding="8,2"
                 ToolTip="{Binding CopiedFilter.Description, StringFormat='Paste filter: {0}', FallbackValue={lex:Loc Key={x:Static res:LocalizationKeys+Distribution.PasteFilterTooltip}}}" />


### PR DESCRIPTION
The auto-save introduced in v1.12.0 caused silent data loss — reactive pipeline writes races with explicit saves, with in-flight writes to a previously-selected file's path, and with non-atomic WriteAllText truncation. Multiple users reported 100+ entry distribution files being wiped or emptied.

Remove the auto-save subscription, the AutoSaveFile method, the ShowAutoSaveIndicator state, and its XAML binding. Keep the PromptAndSaveIfNeeded unsaved-changes flow from the same commit — that part is safe and useful in isolation.

Add DistributionFileBackupService. Before each overwrite, it copies the existing file to %LOCALAPPDATA%\Boutique\Backups\<filename>_<shortHash>\ and prunes to the 15 most recent. Backup failures never block the user's save. Location is outside the Skyrim Data tree so it survives MO2/Vortex VFS writes and isn't picked up by SPID/SkyPatcher's load scanner.