### PR TITLE
Set up code coverage with Codecov PR enforcement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,18 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal
+        run: >
+          dotnet test --configuration Release --no-build --verbosity normal
+          --collect:"XPlat Code Coverage"
+          --settings coverlet.runsettings
+          --results-directory ./coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/**/coverage.cobertura.xml
+          fail_ci_if_error: false
 
       - name: Publish
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ nul
 .github/skills/
 .opencode/
 docs/
+
+# Code coverage output
+TestResults/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: false
+    patch:
+      default:
+        target: 70%
+        threshold: 0%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "**/Views/**"
+  - "**/Controls/**"
+  - "**/*.xaml.cs"
+  - "**/*.g.cs"
+  - "Boutique.Tests/**"

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Exclude>[Boutique]Boutique.Views.*,[Boutique]Boutique.Controls.*,[Boutique]Boutique.App</Exclude>
+          <ExcludeByFile>**/*.xaml.cs,**/*.g.cs,**/*.g.i.cs,**/obj/**,**/bin/**</ExcludeByFile>
+          <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute,DebuggerNonUserCodeAttribute</ExcludeByAttribute>
+          <SkipAutoProps>true</SkipAutoProps>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/scripts/coverage.ps1
+++ b/scripts/coverage.ps1
@@ -4,6 +4,7 @@ param(
 
 $projectRoot = Split-Path $PSScriptRoot -Parent
 $testProject = Join-Path $projectRoot "Boutique.Tests" "Boutique.Tests.csproj"
+$runSettings = Join-Path $projectRoot "coverlet.runsettings"
 $coverageDir = Join-Path $projectRoot "artifacts" "coverage"
 $reportDir = Join-Path $coverageDir "report"
 
@@ -14,9 +15,8 @@ if (Test-Path $coverageDir) {
 Write-Host "Running tests with coverage..." -ForegroundColor Cyan
 dotnet test $testProject `
     --collect:"XPlat Code Coverage" `
-    --results-directory $coverageDir `
-    -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura `
-       DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByAttribute=GeneratedCodeAttribute
+    --settings $runSettings `
+    --results-directory $coverageDir
 
 $coverageFile = Get-ChildItem -Path $coverageDir -Filter "coverage.cobertura.xml" -Recurse | Select-Object -First 1
 
@@ -29,8 +29,13 @@ Write-Host "Generating HTML report..." -ForegroundColor Cyan
 reportgenerator `
     "-reports:$($coverageFile.FullName)" `
     "-targetdir:$reportDir" `
-    "-reporttypes:Html" `
+    "-reporttypes:Html;TextSummary" `
     "-assemblyfilters:+Boutique;-Boutique.Tests"
+
+$summaryFile = Join-Path $reportDir "Summary.txt"
+if (Test-Path $summaryFile) {
+    Get-Content $summaryFile
+}
 
 $indexFile = Join-Path $reportDir "index.html"
 Write-Host "Report generated at: $indexFile" -ForegroundColor Green

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,6 +5,12 @@
       "source": "vercel-labs/skills",
       "sourceType": "github",
       "computedHash": "645b891da1edbae76ab79c7b088d4e73397464f8396edaf773c0e01971ce75d6"
+    },
+    "wpf-best-practices": {
+      "source": "jcurbelo/skills",
+      "sourceType": "github",
+      "skillPath": "wpf-best-practices/SKILL.md",
+      "computedHash": "2cfff70acaa5ef2e531737a9bd04d0aef562fd795d8dba82af20a421c1c9d778"
     }
   }
 }


### PR DESCRIPTION
## Summary

Sets up code coverage that reflects **testable logic** (excludes the WPF/XAML layer) and enforces it on PRs via Codecov, so the complexity refactors land with test visibility instead of blind.

## Changes

### Local tooling
- **`coverlet.runsettings`** — excludes `Boutique.Views.*`, `Boutique.Controls.*`, `Boutique.App`, and generated/code-behind (`*.xaml.cs`, `*.g.cs`) at collection time.
- **`scripts/coverage.ps1`** — drives collection via the runsettings and prints a text summary alongside the browsable HTML report (`artifacts/coverage/report/index.html`).
- **`.gitignore`** — ignore `TestResults/`.

### CI enforcement
- **`.github/workflows/build.yml`** — the Test step now collects Cobertura coverage and uploads it to Codecov (`codecov/codecov-action@v5`, non-blocking upload).
- **`codecov.yml`** — gates:
  - **patch: 70%** — new/changed lines in a PR must be ≥70% covered (the real gate).
  - **project: auto, 1% threshold** — flags regressions without blocking on the 13.7% legacy baseline.

## Current baseline (filtered)

| Metric | Coverage |
|--------|---------:|
| Line | 13.7% |
| Branch | 12.4% |
| Method | 13.2% |

## Manual setup required (one-time)

1. Sign in to **codecov.io** with GitHub, enable `aglowinthefield/boutique`.
2. Copy the repo **upload token**.
3. Add it as a GitHub Actions secret named **`CODECOV_TOKEN`** (repo Settings → Secrets and variables → Actions).
4. (To make the gate *block* merges) Add the **`codecov/patch`** and **`codecov/project`** status checks as required in branch protection for `main`.

Until the token is added, CI stays green (upload is non-blocking) but Codecov status checks won't post.