### PR TITLE
Reduce cognitive complexity of BuildMatchCriteria (test-first)

### DIFF
--- a/Boutique.Tests/FilterMatchingServiceBuildCriteriaTests.cs
+++ b/Boutique.Tests/FilterMatchingServiceBuildCriteriaTests.cs
@@ -1,0 +1,332 @@
+using Boutique.Models;
+using Boutique.Services;
+using FluentAssertions;
+using Mutagen.Bethesda.Plugins;
+using Xunit;
+
+namespace Boutique.Tests;
+
+/// <summary>
+///   Characterization tests pinning the exact behavior of BuildMatchCriteria (reached via
+///   GetMatchingNpcsForEntry) before refactoring it for cognitive complexity. Each test asserts the
+///   precise criteria string assembled for a matching NPC, or that a non-matching NPC is filtered out.
+/// </summary>
+public class FilterMatchingServiceBuildCriteriaTests
+{
+  private static readonly ModKey TestMod = ModKey.FromNameAndExtension("Skyrim.esm");
+
+  private static FormKey Fk(uint id) => new(TestMod, id);
+
+  private static string? Criteria(
+    NpcFilterData npc,
+    DistributionEntry entry,
+    IReadOnlyDictionary<FormKey, HashSet<string>>? virtualKeywords = null)
+  {
+    var results = FilterMatchingService.GetMatchingNpcsForEntry([npc], entry, virtualKeywords);
+    return results.Count == 0 ? null : results[0].Criteria;
+  }
+
+  [Fact]
+  public void NoFilters_ReturnsAllNpcs()
+  {
+    Criteria(new NpcBuilder().Build(), new DistributionEntry()).Should().Be("All NPCs");
+  }
+
+  [Fact]
+  public void RawStringWildcard_Match_AddsStringPart()
+  {
+    var npc = new NpcBuilder { Name = "Whiterun Guard" }.Build();
+    var entry = new DistributionEntry { RawStringFilters = "*Guard" };
+    Criteria(npc, entry).Should().Be("String: *Guard");
+  }
+
+  [Fact]
+  public void RawStringWildcard_NoMatch_ReturnsNull()
+  {
+    var npc = new NpcBuilder { Name = "Bandit" }.Build();
+    var entry = new DistributionEntry { RawStringFilters = "*Guard" };
+    Criteria(npc, entry).Should().BeNull();
+  }
+
+  [Fact]
+  public void RawStringExact_MatchViaMatchKeys_AddsStringPart()
+  {
+    var npc = new NpcBuilder { MatchKeys = new HashSet<string> { "ActorTypeNPC" } }.Build();
+    var entry = new DistributionEntry { RawStringFilters = "ActorTypeNPC" };
+    Criteria(npc, entry).Should().Be("String: ActorTypeNPC");
+  }
+
+  [Fact]
+  public void NpcFilter_Included_AddsNpcPartWithDisplayName()
+  {
+    var npc = new NpcBuilder { Name = "Lydia" }.Build();
+    var entry = new DistributionEntry { NpcFilters = [new FormKeyFilter(npc.FormKey)] };
+    Criteria(npc, entry).Should().Be("NPC: Lydia");
+  }
+
+  [Fact]
+  public void NpcFilter_ExcludedMatching_ReturnsNull()
+  {
+    var npc = new NpcBuilder().Build();
+    var entry = new DistributionEntry { NpcFilters = [new FormKeyFilter(npc.FormKey, IsExcluded: true)] };
+    Criteria(npc, entry).Should().BeNull();
+  }
+
+  [Fact]
+  public void NpcFilter_IncludedNonMatching_ReturnsNull()
+  {
+    var npc = new NpcBuilder().Build();
+    var entry = new DistributionEntry { NpcFilters = [new FormKeyFilter(Fk(0xDEAD))] };
+    Criteria(npc, entry).Should().BeNull();
+  }
+
+  [Fact]
+  public void FactionFilter_Included_AddsFactionPartWithEditorId()
+  {
+    var npc = new NpcBuilder
+    {
+      Factions = [new FactionMembership { FactionFormKey = Fk(0xF1), FactionEditorId = "MyFaction", Rank = 0 }]
+    }.Build();
+    var entry = new DistributionEntry { FactionFilters = [new FormKeyFilter(Fk(0xF1))] };
+    Criteria(npc, entry).Should().Be("Faction: MyFaction");
+  }
+
+  [Fact]
+  public void KeywordFilter_Included_AddsKeywordPart()
+  {
+    var npc = new NpcBuilder { Keywords = new HashSet<string> { "ActorTypeNPC" } }.Build();
+    var entry = new DistributionEntry { KeywordFilters = [new KeywordFilter("ActorTypeNPC")] };
+    Criteria(npc, entry).Should().Be("Keyword: ActorTypeNPC");
+  }
+
+  [Fact]
+  public void KeywordFilter_VirtualKeyword_AddsKeywordPart()
+  {
+    var npc = new NpcBuilder().Build();
+    var entry = new DistributionEntry { KeywordFilters = [new KeywordFilter("VirtualKw")] };
+    var virtualKeywords = new Dictionary<FormKey, HashSet<string>> { [npc.FormKey] = ["VirtualKw"] };
+    Criteria(npc, entry, virtualKeywords).Should().Be("Keyword: VirtualKw");
+  }
+
+  [Fact]
+  public void RaceFilter_Included_AddsRacePartWithEditorId()
+  {
+    var npc = new NpcBuilder { RaceFormKey = Fk(0x2), RaceEditorId = "NordRace" }.Build();
+    var entry = new DistributionEntry { RaceFilters = [new FormKeyFilter(Fk(0x2))] };
+    Criteria(npc, entry).Should().Be("Race: NordRace");
+  }
+
+  [Fact]
+  public void ClassFilter_Match_AddsClassPart()
+  {
+    var npc = new NpcBuilder { ClassFormKey = Fk(0x3), ClassEditorId = "WarriorClass" }.Build();
+    var entry = new DistributionEntry { ClassFormKeys = [Fk(0x3)] };
+    Criteria(npc, entry).Should().Be("Class: WarriorClass");
+  }
+
+  [Fact]
+  public void ClassFilter_NoMatch_ReturnsNull()
+  {
+    var npc = new NpcBuilder { ClassFormKey = Fk(0x3) }.Build();
+    var entry = new DistributionEntry { ClassFormKeys = [Fk(0x99)] };
+    Criteria(npc, entry).Should().BeNull();
+  }
+
+  [Fact]
+  public void OutfitFilter_Match_AddsOutfitPart()
+  {
+    var npc = new NpcBuilder { DefaultOutfitFormKey = Fk(0x4), DefaultOutfitEditorId = "DefOutfit" }.Build();
+    var entry = new DistributionEntry { OutfitFilterFormKeys = [Fk(0x4)] };
+    Criteria(npc, entry).Should().Be("Outfit: DefOutfit");
+  }
+
+  [Fact]
+  public void CombatStyleFilter_Match_AddsCombatStylePart()
+  {
+    var npc = new NpcBuilder { CombatStyleFormKey = Fk(0x5), CombatStyleEditorId = "csMagic" }.Build();
+    var entry = new DistributionEntry { CombatStyleFormKeys = [Fk(0x5)] };
+    Criteria(npc, entry).Should().Be("CombatStyle: csMagic");
+  }
+
+  [Fact]
+  public void VoiceTypeFilter_Match_AddsVoiceTypePart()
+  {
+    var npc = new NpcBuilder { VoiceTypeFormKey = Fk(0x6), VoiceTypeEditorId = "MaleNord" }.Build();
+    var entry = new DistributionEntry { VoiceTypeFormKeys = [Fk(0x6)] };
+    Criteria(npc, entry).Should().Be("VoiceType: MaleNord");
+  }
+
+  [Fact]
+  public void LevelFilter_InRange_AddsLevelPart()
+  {
+    var npc = new NpcBuilder { Level = 10 }.Build();
+    var entry = new DistributionEntry { LevelFilters = "5/20" };
+    Criteria(npc, entry).Should().Be("Level: 5/20");
+  }
+
+  [Fact]
+  public void LevelFilter_OutOfRange_ReturnsNull()
+  {
+    var npc = new NpcBuilder { Level = 3 }.Build();
+    var entry = new DistributionEntry { LevelFilters = "5/20" };
+    Criteria(npc, entry).Should().BeNull();
+  }
+
+  [Fact]
+  public void LevelFilter_None_NotAddedAndMatches()
+  {
+    var npc = new NpcBuilder().Build();
+    var entry = new DistributionEntry { LevelFilters = "NONE" };
+    Criteria(npc, entry).Should().Be("All NPCs");
+  }
+
+  [Fact]
+  public void TraitFilter_FemaleMatch_AddsFemaleTrait()
+  {
+    var npc = new NpcBuilder { IsFemale = true }.Build();
+    var entry = new DistributionEntry { TraitFilters = new SpidTraitFilters { IsFemale = true } };
+    Criteria(npc, entry).Should().Be("Female");
+  }
+
+  [Fact]
+  public void TraitFilter_FemaleNoMatch_ReturnsNull()
+  {
+    var npc = new NpcBuilder { IsFemale = false }.Build();
+    var entry = new DistributionEntry { TraitFilters = new SpidTraitFilters { IsFemale = true } };
+    Criteria(npc, entry).Should().BeNull();
+  }
+
+  [Fact]
+  public void TraitFilter_TeammateDescribedButNotGated()
+  {
+    var npc = new NpcBuilder().Build();
+    var entry = new DistributionEntry { TraitFilters = new SpidTraitFilters { IsTeammate = true } };
+    Criteria(npc, entry).Should().Be("Teammate");
+  }
+
+  [Fact]
+  public void LocationFilter_Match_AddsLocationPart()
+  {
+    var npc = new NpcBuilder { Locations = new HashSet<FormKey> { Fk(0x7) } }.Build();
+    var entry = new DistributionEntry { LocationFormKeys = [Fk(0x7)] };
+    Criteria(npc, entry).Should().Be("Location: (1 filter(s))");
+  }
+
+  [Fact]
+  public void LocationFilter_NoMatch_ReturnsNull()
+  {
+    var npc = new NpcBuilder { Locations = new HashSet<FormKey> { Fk(0x7) } }.Build();
+    var entry = new DistributionEntry { LocationFormKeys = [Fk(0x8)] };
+    Criteria(npc, entry).Should().BeNull();
+  }
+
+  [Fact]
+  public void UnresolvedOnly_NoOtherParts_ReturnsNull()
+  {
+    var npc = new NpcBuilder().Build();
+    var entry = new DistributionEntry { PerkFormKeys = [Fk(0x10)] };
+    Criteria(npc, entry).Should().BeNull();
+  }
+
+  [Fact]
+  public void UnresolvedPerk_WithOtherPart_AddsUnresolvedPart()
+  {
+    var npc = new NpcBuilder { ClassFormKey = Fk(0x3), ClassEditorId = "WarriorClass" }.Build();
+    var entry = new DistributionEntry { ClassFormKeys = [Fk(0x3)], PerkFormKeys = [Fk(0x10)] };
+    Criteria(npc, entry).Should().Be("Class: WarriorClass; Unresolved: Perk (1)");
+  }
+
+  [Fact]
+  public void UnresolvedRawForm_WithOtherPart_AddsFormUnresolved()
+  {
+    var npc = new NpcBuilder { ClassFormKey = Fk(0x3), ClassEditorId = "WarriorClass" }.Build();
+    var entry = new DistributionEntry { ClassFormKeys = [Fk(0x3)], RawFormFilters = "0x123~Other.esp" };
+    Criteria(npc, entry).Should().Be("Class: WarriorClass; Unresolved: Form: 0x123~Other.esp");
+  }
+
+  [Fact]
+  public void MultipleFilters_AssembledInDeclaredOrder()
+  {
+    var npc = new NpcBuilder
+    {
+      Name = "Lydia",
+      Keywords = new HashSet<string> { "ActorTypeNPC" },
+      Factions = [new FactionMembership { FactionFormKey = Fk(0xF1), FactionEditorId = "MyFaction", Rank = 0 }],
+      ClassFormKey = Fk(0x3),
+      ClassEditorId = "WarriorClass"
+    }.Build();
+
+    var entry = new DistributionEntry
+    {
+      NpcFilters = [new FormKeyFilter(npc.FormKey)],
+      FactionFilters = [new FormKeyFilter(Fk(0xF1))],
+      KeywordFilters = [new KeywordFilter("ActorTypeNPC")],
+      ClassFormKeys = [Fk(0x3)]
+    };
+
+    Criteria(npc, entry).Should().Be("NPC: Lydia; Faction: MyFaction; Keyword: ActorTypeNPC; Class: WarriorClass");
+  }
+
+  private sealed class NpcBuilder
+  {
+    public FormKey FormKey { get; init; } = new(TestMod, 0x800);
+    public string? Name { get; init; } = "TestNpc";
+    public string? EditorId { get; init; } = "TestNpcEditorId";
+    public ModKey SourceMod { get; init; } = TestMod;
+    public IReadOnlySet<string> Keywords { get; init; } = new HashSet<string>();
+    public IReadOnlyList<FactionMembership> Factions { get; init; } = [];
+    public FormKey? RaceFormKey { get; init; }
+    public string? RaceEditorId { get; init; }
+    public FormKey? ClassFormKey { get; init; }
+    public string? ClassEditorId { get; init; }
+    public FormKey? CombatStyleFormKey { get; init; }
+    public string? CombatStyleEditorId { get; init; }
+    public FormKey? VoiceTypeFormKey { get; init; }
+    public string? VoiceTypeEditorId { get; init; }
+    public FormKey? DefaultOutfitFormKey { get; init; }
+    public string? DefaultOutfitEditorId { get; init; }
+    public bool IsFemale { get; init; }
+    public bool IsUnique { get; init; }
+    public bool IsSummonable { get; init; }
+    public bool IsChild { get; init; }
+    public bool IsLeveled { get; init; }
+    public short Level { get; init; } = 1;
+    public IReadOnlySet<FormKey> Locations { get; init; } = new HashSet<FormKey>();
+    public FormKey? TemplateFormKey { get; init; }
+    public string? TemplateEditorId { get; init; }
+    public HashSet<string>? MatchKeys { get; init; }
+    public byte[] SkillValues { get; init; } = new byte[24];
+
+    public NpcFilterData Build() => new()
+    {
+      FormKey = FormKey,
+      EditorId = EditorId,
+      Name = Name,
+      SourceMod = SourceMod,
+      Keywords = Keywords,
+      Factions = Factions,
+      RaceFormKey = RaceFormKey,
+      RaceEditorId = RaceEditorId,
+      ClassFormKey = ClassFormKey,
+      ClassEditorId = ClassEditorId,
+      CombatStyleFormKey = CombatStyleFormKey,
+      CombatStyleEditorId = CombatStyleEditorId,
+      VoiceTypeFormKey = VoiceTypeFormKey,
+      VoiceTypeEditorId = VoiceTypeEditorId,
+      DefaultOutfitFormKey = DefaultOutfitFormKey,
+      DefaultOutfitEditorId = DefaultOutfitEditorId,
+      WornArmorFormKey = null,
+      IsFemale = IsFemale,
+      IsUnique = IsUnique,
+      IsSummonable = IsSummonable,
+      IsChild = IsChild,
+      IsLeveled = IsLeveled,
+      Level = Level,
+      Locations = Locations,
+      TemplateFormKey = TemplateFormKey,
+      TemplateEditorId = TemplateEditorId,
+      SkillValues = SkillValues,
+      MatchKeys = MatchKeys
+    };
+  }
+}

--- a/Services/FilterMatchingService.cs
+++ b/Services/FilterMatchingService.cs
@@ -75,10 +75,7 @@ public static class FilterMatchingService
       return null;
     }
 
-    if (!string.IsNullOrWhiteSpace(entry.RawStringFilters))
-    {
-      parts.Add($"String: {entry.RawStringFilters}");
-    }
+    AddIfNotEmpty(parts, string.IsNullOrWhiteSpace(entry.RawStringFilters) ? null : $"String: {entry.RawStringFilters}");
 
     if (!MatchesFilters(entry.NpcFilters, f => f.FormKey, [npc.FormKey], entry.NpcLogicMode))
     {
@@ -96,44 +93,15 @@ public static class FilterMatchingService
       return null;
     }
 
-    if (entry.FactionFilters.Any(f => !f.IsExcluded))
-    {
-      var matched = entry.FactionFilters
-                         .Where(f => !f.IsExcluded && npcFactions.Contains(f.FormKey))
-                         .Select(f =>
-                                   npc.Factions.FirstOrDefault(nf => nf.FactionFormKey == f.FormKey)?.FactionEditorId ??
-                                   f.FormKey.ToString());
-      var str = string.Join(" + ", matched);
-      if (!string.IsNullOrEmpty(str))
-      {
-        parts.Add($"Faction: {str}");
-      }
-    }
+    AddIfNotEmpty(parts, DescribeFactionMatch(entry, npc, npcFactions));
 
-    IReadOnlyCollection<string> effectiveKeywords = npc.Keywords;
-    if (virtualKeywords != null && entry.KeywordFilters.Count > 0)
-    {
-      var augmented = new HashSet<string>(npc.Keywords, StringComparer.OrdinalIgnoreCase);
-      augmented.UnionWith(virtualKeywords);
-      effectiveKeywords = augmented;
-    }
-
+    var effectiveKeywords = BuildEffectiveKeywords(npc, entry, virtualKeywords);
     if (!MatchesFilters(entry.KeywordFilters, f => f.EditorId, effectiveKeywords, entry.KeywordLogicMode))
     {
       return null;
     }
 
-    if (entry.KeywordFilters.Any(f => !f.IsExcluded))
-    {
-      var matched = entry.KeywordFilters
-                         .Where(f => !f.IsExcluded && effectiveKeywords.Contains(f.EditorId))
-                         .Select(f => f.EditorId);
-      var str = string.Join(" + ", matched);
-      if (!string.IsNullOrEmpty(str))
-      {
-        parts.Add($"Keyword: {str}");
-      }
-    }
+    AddIfNotEmpty(parts, DescribeKeywordMatch(entry, effectiveKeywords));
 
     if (!MatchesFilters(
           entry.RaceFilters,
@@ -149,48 +117,27 @@ public static class FilterMatchingService
       parts.Add($"Race: {npc.RaceEditorId ?? npc.RaceFormKey?.ToString() ?? "?"}");
     }
 
-    if (entry.ClassFormKeys.Count > 0 &&
-        (!npc.ClassFormKey.HasValue || !entry.ClassFormKeys.Contains(npc.ClassFormKey.Value)))
+    if (!TryDescribeFormKeySetFilter(entry.ClassFormKeys, npc.ClassFormKey, npc.ClassEditorId, "Class", parts) ||
+        !TryDescribeFormKeySetFilter(
+          entry.OutfitFilterFormKeys,
+          npc.DefaultOutfitFormKey,
+          npc.DefaultOutfitEditorId,
+          "Outfit",
+          parts) ||
+        !TryDescribeFormKeySetFilter(
+          entry.CombatStyleFormKeys,
+          npc.CombatStyleFormKey,
+          npc.CombatStyleEditorId,
+          "CombatStyle",
+          parts) ||
+        !TryDescribeFormKeySetFilter(
+          entry.VoiceTypeFormKeys,
+          npc.VoiceTypeFormKey,
+          npc.VoiceTypeEditorId,
+          "VoiceType",
+          parts))
     {
       return null;
-    }
-
-    if (entry.ClassFormKeys.Count > 0)
-    {
-      parts.Add($"Class: {npc.ClassEditorId ?? npc.ClassFormKey?.ToString() ?? "?"}");
-    }
-
-    if (entry.OutfitFilterFormKeys.Count > 0 &&
-        (!npc.DefaultOutfitFormKey.HasValue || !entry.OutfitFilterFormKeys.Contains(npc.DefaultOutfitFormKey.Value)))
-    {
-      return null;
-    }
-
-    if (entry.OutfitFilterFormKeys.Count > 0)
-    {
-      parts.Add($"Outfit: {npc.DefaultOutfitEditorId ?? npc.DefaultOutfitFormKey?.ToString() ?? "?"}");
-    }
-
-    if (entry.CombatStyleFormKeys.Count > 0 &&
-        (!npc.CombatStyleFormKey.HasValue || !entry.CombatStyleFormKeys.Contains(npc.CombatStyleFormKey.Value)))
-    {
-      return null;
-    }
-
-    if (entry.CombatStyleFormKeys.Count > 0)
-    {
-      parts.Add($"CombatStyle: {npc.CombatStyleEditorId ?? npc.CombatStyleFormKey?.ToString() ?? "?"}");
-    }
-
-    if (entry.VoiceTypeFormKeys.Count > 0 &&
-        (!npc.VoiceTypeFormKey.HasValue || !entry.VoiceTypeFormKeys.Contains(npc.VoiceTypeFormKey.Value)))
-    {
-      return null;
-    }
-
-    if (entry.VoiceTypeFormKeys.Count > 0)
-    {
-      parts.Add($"VoiceType: {npc.VoiceTypeEditorId ?? npc.VoiceTypeFormKey?.ToString() ?? "?"}");
     }
 
     if (!MatchesLevelFilters(npc, entry.LevelFilters))
@@ -209,48 +156,145 @@ public static class FilterMatchingService
       return null;
     }
 
-    if (!entry.TraitFilters.IsEmpty)
+    AddIfNotEmpty(parts, DescribeTraits(entry.TraitFilters));
+
+    if (!TryDescribeLocationFilter(entry, npc, parts))
     {
-      ReadOnlySpan<(bool? value, string trueName, string falseName)> traitLabels =
-      [
-        (entry.TraitFilters.IsFemale, "Female", "Male"),
-        (entry.TraitFilters.IsUnique, "Unique", "Not Unique"),
-        (entry.TraitFilters.IsSummonable, "Summonable", "Not Summonable"),
-        (entry.TraitFilters.IsChild, "Child", "Not Child"),
-        (entry.TraitFilters.IsLeveled, "Leveled", "Not Leveled"),
-        (entry.TraitFilters.IsTemplated, "Templated", "Not Templated"),
-        (entry.TraitFilters.IsTeammate, "Teammate", "Not Teammate"),
-        (entry.TraitFilters.IsDead, "Dead", "Not Dead"),
-      ];
+      return null;
+    }
 
-      var traits = new List<string>();
-      foreach (var (value, trueName, falseName) in traitLabels)
-      {
-        if (value.HasValue)
-        {
-          traits.Add(value.Value ? trueName : falseName);
-        }
-      }
+    return AppendUnresolvedAndFinalize(entry, parts);
+  }
 
-      if (traits.Count > 0)
+  private static void AddIfNotEmpty(List<string> parts, string? part)
+  {
+    if (!string.IsNullOrEmpty(part))
+    {
+      parts.Add(part);
+    }
+  }
+
+  private static IReadOnlyCollection<string> BuildEffectiveKeywords(
+    NpcFilterData npc,
+    DistributionEntry entry,
+    IReadOnlySet<string>? virtualKeywords)
+  {
+    if (virtualKeywords == null || entry.KeywordFilters.Count == 0)
+    {
+      return npc.Keywords;
+    }
+
+    var augmented = new HashSet<string>(npc.Keywords, StringComparer.OrdinalIgnoreCase);
+    augmented.UnionWith(virtualKeywords);
+    return augmented;
+  }
+
+  private static string? DescribeFactionMatch(
+    DistributionEntry entry,
+    NpcFilterData npc,
+    HashSet<FormKey> npcFactions)
+  {
+    if (!entry.FactionFilters.Any(f => !f.IsExcluded))
+    {
+      return null;
+    }
+
+    var matched = entry.FactionFilters
+                       .Where(f => !f.IsExcluded && npcFactions.Contains(f.FormKey))
+                       .Select(f =>
+                                 npc.Factions.FirstOrDefault(nf => nf.FactionFormKey == f.FormKey)?.FactionEditorId ??
+                                 f.FormKey.ToString());
+    var str = string.Join(" + ", matched);
+    return string.IsNullOrEmpty(str) ? null : $"Faction: {str}";
+  }
+
+  private static string? DescribeKeywordMatch(DistributionEntry entry, IReadOnlyCollection<string> effectiveKeywords)
+  {
+    if (!entry.KeywordFilters.Any(f => !f.IsExcluded))
+    {
+      return null;
+    }
+
+    var matched = entry.KeywordFilters
+                       .Where(f => !f.IsExcluded && effectiveKeywords.Contains(f.EditorId))
+                       .Select(f => f.EditorId);
+    var str = string.Join(" + ", matched);
+    return string.IsNullOrEmpty(str) ? null : $"Keyword: {str}";
+  }
+
+  private static bool TryDescribeFormKeySetFilter(
+    List<FormKey> filterKeys,
+    FormKey? npcValue,
+    string? npcEditorId,
+    string label,
+    List<string> parts)
+  {
+    if (filterKeys.Count == 0)
+    {
+      return true;
+    }
+
+    if (!npcValue.HasValue || !filterKeys.Contains(npcValue.Value))
+    {
+      return false;
+    }
+
+    parts.Add($"{label}: {npcEditorId ?? npcValue?.ToString() ?? "?"}");
+    return true;
+  }
+
+  private static string? DescribeTraits(SpidTraitFilters traitFilters)
+  {
+    if (traitFilters.IsEmpty)
+    {
+      return null;
+    }
+
+    ReadOnlySpan<(bool? value, string trueName, string falseName)> traitLabels =
+    [
+      (traitFilters.IsFemale, "Female", "Male"),
+      (traitFilters.IsUnique, "Unique", "Not Unique"),
+      (traitFilters.IsSummonable, "Summonable", "Not Summonable"),
+      (traitFilters.IsChild, "Child", "Not Child"),
+      (traitFilters.IsLeveled, "Leveled", "Not Leveled"),
+      (traitFilters.IsTemplated, "Templated", "Not Templated"),
+      (traitFilters.IsTeammate, "Teammate", "Not Teammate"),
+      (traitFilters.IsDead, "Dead", "Not Dead"),
+    ];
+
+    var traits = new List<string>();
+    foreach (var (value, trueName, falseName) in traitLabels)
+    {
+      if (value.HasValue)
       {
-        parts.Add(string.Join(", ", traits));
+        traits.Add(value.Value ? trueName : falseName);
       }
     }
 
-    if (entry.LocationFormKeys.Count > 0)
-    {
-      var locationMatches = entry.LocationLogicMode == FilterLogicMode.Or
-                              ? entry.LocationFormKeys.Any(npc.Locations.Contains)
-                              : entry.LocationFormKeys.All(npc.Locations.Contains);
-      if (!locationMatches)
-      {
-        return null;
-      }
+    return traits.Count > 0 ? string.Join(", ", traits) : null;
+  }
 
-      parts.Add($"Location: ({entry.LocationFormKeys.Count} filter(s))");
+  private static bool TryDescribeLocationFilter(DistributionEntry entry, NpcFilterData npc, List<string> parts)
+  {
+    if (entry.LocationFormKeys.Count == 0)
+    {
+      return true;
     }
 
+    var locationMatches = entry.LocationLogicMode == FilterLogicMode.Or
+                            ? entry.LocationFormKeys.Any(npc.Locations.Contains)
+                            : entry.LocationFormKeys.All(npc.Locations.Contains);
+    if (!locationMatches)
+    {
+      return false;
+    }
+
+    parts.Add($"Location: ({entry.LocationFormKeys.Count} filter(s))");
+    return true;
+  }
+
+  private static string? AppendUnresolvedAndFinalize(DistributionEntry entry, List<string> parts)
+  {
     var unresolvedParts = new List<string>();
 
     if (entry.PerkFormKeys.Count > 0)


### PR DESCRIPTION
## Summary

First **test-first** complexity refactor. Reduces `FilterMatchingService.BuildMatchCriteria` S3776 cognitive complexity from **60 → under 25** (also clears the method's `S138` 177-line and `CA1502` warnings), guarded by a new characterization suite. This was the highest-complexity item in the backlog and was previously at ~1.2% coverage.

## Approach

1. **Wrote a 28-test characterization suite first** (`FilterMatchingServiceBuildCriteriaTests`) pinning the exact criteria string `BuildMatchCriteria` produces (via the public `GetMatchingNpcsForEntry`) across every filter category, the gate→null behavior, the `; `-joined assembly order, and edge cases ("All NPCs", unresolved-only → null, virtual keywords, trait labels that describe but don't gate).
2. Confirmed all 28 **green against the unrefactored code**.
3. Refactored underneath them:
   - Collapsed the four **identical** form-key-set filters (Class/Outfit/CombatStyle/VoiceType) into one `TryDescribeFormKeySetFilter` helper.
   - Extracted faction/keyword/trait/location describe-building and the unresolved-finalize tail into focused helpers.
   - Main method is now a flat linear sequence of gate + describe steps.

## Verification

- **All 1153 tests pass** (1125 existing + 28 new).
- No new analyzer warnings (the introduced `CA1859` was addressed).
- `FilterMatchingService` line coverage **1.2% → 67.4%**.
- Pure structural refactor — no behavior change.

## Note

This is the first PR to face the **70% patch-coverage gate**; the changed lines are all exercised by the new tests. The pre-existing `CA1502` on `MatchesFormValue` (complexity 31) is a separate target, intentionally left for a follow-up.