### PR TITLE
Loosen PR coverage gate to 60% patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,10 +4,10 @@ coverage:
       default:
         target: auto
         threshold: 1%
-        informational: false
+        informational: true
     patch:
       default:
-        target: 70%
+        target: 60%
         threshold: 0%
 
 comment:


### PR DESCRIPTION
Lowers the patch (diff) coverage target from **70% → 60%** and makes the **project** coverage status **informational** (report-only).

Net effect: the only blocking coverage check is **patch ≥ 60%** on changed lines. Project coverage is still reported (so you can see regressions) but never blocks a merge — appropriate while incrementally improving from a low baseline.

Takes effect for PRs once merged to `main` (Codecov reads `codecov.yml` from the default branch).